### PR TITLE
ci: add takt version auto-upgrade workflow

### DIFF
--- a/.github/workflows/takt-upgrade.yml
+++ b/.github/workflows/takt-upgrade.yml
@@ -1,0 +1,62 @@
+name: takt-upgrade
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 * * * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: takt-upgrade
+  cancel-in-progress: true
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Upgrade takt
+        run: npx -y npm-check-updates -u --filter takt --packageFile package.json
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure Git User
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit changes
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git add package.json
+          git commit -m "chore(deps): bump takt version"
+
+      - name: Push changes
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          PAT: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          git remote set-url origin https://x-access-token:${PAT}@github.com/${{ github.repository }}.git
+          git push origin HEAD:${GITHUB_REF_NAME}


### PR DESCRIPTION
毎時 npm-check-updates で takt のバージョンを確認し、
更新があれば自動コミット・プッシュする。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a scheduled workflow that commits and pushes dependency changes using a repository PAT, which can affect repository integrity if the token is mis-scoped or the workflow is abused. Functional code is unchanged; the main risk is CI/security configuration.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`takt-upgrade.yml`) that runs hourly (and on manual dispatch) to automatically bump the `takt` version in `package.json` via `npm-check-updates`.
> 
> If changes are detected, it configures a bot git user, commits the updated `package.json`, and pushes directly back to the current branch using `secrets.PERSONAL_ACCESS_TOKEN`, with concurrency controls to avoid overlapping runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25f6b6687908ceb0bc2d25a81e1f94eb9426ccdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->