### PR TITLE
docs: add OpenSpec Workflow section to READMEs and fix opsx:explore t…

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -234,6 +234,59 @@ npm run steering:custom -- "testing"
 
 生成されたsteeringファイルは設計フェーズ（`sdd:design`, `sdd:validate-design` 等）で自動的に参照される。
 
+## OpenSpec ワークフロー
+
+SDD ワークフローとは別に、OpenSpec ベースの変更管理ワークフローを提供する。提案 → 実装 → アーカイブの各フェーズで構造化された変更を管理する。
+
+| ピース | 内容 |
+|--------|------|
+| `opsx-propose` | 変更を作成し、全アーティファクト（提案書、設計書、タスク）を生成 |
+| `opsx-apply` | 変更のタスクを実装 |
+| `opsx-archive` | 完了した変更をアーカイブ |
+| `opsx-full` | propose → apply → archive を一括自動実行 |
+| `opsx-explore` | 対話的な探索と思考（読み取り専用、full には含まれない） |
+
+### フルオート実行
+
+```bash
+npm run opsx:full -- "変更の説明"
+```
+
+### フェーズ別実行
+
+```bash
+# 変更を作成しアーティファクトを生成
+npm run opsx:propose -- "change-name"
+
+# タスクを実装
+npm run opsx:apply -- "change-name"
+
+# 完了した変更をアーカイブ
+npm run opsx:archive -- "change-name"
+
+# 対話的な探索（独立した思考モード）
+npm run opsx:explore
+```
+
+### OpenSpec 設定
+
+`openspec/config.yaml` でスキーマとオプションのプロジェクトコンテキストを定義する：
+
+```yaml
+schema: spec-driven
+
+# オプション: アーティファクト作成時にAIに提示するプロジェクトコンテキスト
+# context: |
+#   技術スタック: TypeScript, React, Node.js
+
+# オプション: アーティファクト単位のルール
+# rules:
+#   proposal:
+#     - 提案書は500語以内にする
+```
+
+変更は `openspec/changes/<name>/` に保存され、`openspec/changes/archive/` にアーカイブされる。
+
 ## プロジェクト構造
 
 ```
@@ -263,7 +316,8 @@ references/
 ├── takt/                    # takt ビルトインとドキュメント（submodule / インストーラ）
 └── okite-ai/                # AI ルール集（submodule）
 scripts/
-└── takt.sh                  # takt 実行ラッパー
+├── takt.sh                  # takt 実行ラッパー
+└── opsx-cli.sh              # OpenSpec CLI（変更管理）
 ```
 
 ## 影響を受けたツール

--- a/README.md
+++ b/README.md
@@ -234,6 +234,59 @@ npm run steering:custom -- "testing"
 
 Generated steering files are automatically referenced during design phases (`sdd:design`, `sdd:validate-design`, etc.).
 
+## OpenSpec Workflow
+
+Separate from the SDD workflow, an OpenSpec-based change management workflow is provided. This workflow manages structured changes through proposal → implementation → archival phases.
+
+| Piece | Description |
+|-------|-------------|
+| `opsx-propose` | Create a change and generate all artifacts (proposal, design, tasks) |
+| `opsx-apply` | Implement tasks from a change |
+| `opsx-archive` | Archive a completed change |
+| `opsx-full` | Run propose → apply → archive in one automated sequence |
+| `opsx-explore` | Interactive exploration and thinking (read-only, not included in full) |
+
+### Full-Auto Execution
+
+```bash
+npm run opsx:full -- "description of change"
+```
+
+### Phase-by-Phase Execution
+
+```bash
+# Create a change and generate artifacts
+npm run opsx:propose -- "change-name"
+
+# Implement tasks
+npm run opsx:apply -- "change-name"
+
+# Archive completed change
+npm run opsx:archive -- "change-name"
+
+# Interactive exploration (independent, thinking-only mode)
+npm run opsx:explore
+```
+
+### OpenSpec Configuration
+
+The `openspec/config.yaml` file defines the schema and optional project context:
+
+```yaml
+schema: spec-driven
+
+# Optional: project context shown to AI when creating artifacts
+# context: |
+#   Tech stack: TypeScript, React, Node.js
+
+# Optional: per-artifact rules
+# rules:
+#   proposal:
+#     - Keep proposals under 500 words
+```
+
+Changes are stored in `openspec/changes/<name>/` and archived to `openspec/changes/archive/`.
+
 ## Project Structure
 
 ```
@@ -263,7 +316,8 @@ references/
 ├── takt/                    # takt builtins and docs (submodule / installer)
 └── okite-ai/                # AI rules collection (submodule)
 scripts/
-└── takt.sh                  # takt execution wrapper
+├── takt.sh                  # takt execution wrapper
+└── opsx-cli.sh              # OpenSpec CLI (change management)
 ```
 
 ## Inspired By

--- a/installer/src/i18n.ts
+++ b/installer/src/i18n.ts
@@ -98,7 +98,7 @@ Options:
     npm run opsx:propose -- "change-name"
     npm run opsx:apply -- "change-name"
     npm run opsx:archive -- "change-name"
-    npm run opsx:explore -- "topic to explore"`,
+    npm run opsx:explore`,
 };
 
 const ja: Messages = {
@@ -166,7 +166,7 @@ const ja: Messages = {
     npm run opsx:propose -- "change-name"
     npm run opsx:apply -- "change-name"
     npm run opsx:archive -- "change-name"
-    npm run opsx:explore -- "探索したいトピック"`,
+    npm run opsx:explore`,
 };
 
 const messages: Record<Lang, Messages> = { en, ja };

--- a/installer/src/install.ts
+++ b/installer/src/install.ts
@@ -97,7 +97,7 @@ const SDD_SCRIPTS: Record<string, string> = {
   "opsx:propose": "takt --pipeline --skip-git --create-worktree no -w opsx-propose -t",
   "opsx:apply": "takt --pipeline --skip-git --create-worktree no -w opsx-apply -t",
   "opsx:archive": "takt --pipeline --skip-git --create-worktree no -w opsx-archive -t",
-  "opsx:explore": "takt --pipeline --skip-git --create-worktree no -w opsx-explore -t",
+  "opsx:explore": "takt --skip-git --create-worktree no -w opsx-explore",
 };
 
 export interface InstallOptions {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "opsx:propose": "scripts/takt.sh --pipeline --skip-git --create-worktree no -w opsx-propose -t",
     "opsx:apply": "scripts/takt.sh --pipeline --skip-git --create-worktree no -w opsx-apply -t",
     "opsx:archive": "scripts/takt.sh --pipeline --skip-git --create-worktree no -w opsx-archive -t",
-    "opsx:explore": "scripts/takt.sh --pipeline --skip-git --create-worktree no -w opsx-explore -t"
+    "opsx:explore": "scripts/takt.sh --skip-git --create-worktree no -w opsx-explore"
   }
 }


### PR DESCRIPTION
…o interactive mode

- Add OpenSpec Workflow section (en/ja) with piece descriptions, usage, and config
- Add opsx-cli.sh to Project Structure in both READMEs
- Remove --pipeline and -t flags from opsx:explore (interactive mode, not pipeline)
- Update installer and i18n usage examples accordingly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation and script wiring changes; the only behavioral change is `opsx:explore` now runs non-pipeline interactive mode, which could affect anyone relying on the previous (likely broken) pipeline invocation.
> 
> **Overview**
> Adds an **OpenSpec change-management workflow** section to both `README.md` and `README.ja.md`, documenting the propose/apply/archive/full/explore pieces, usage examples, and `openspec/config.yaml` configuration.
> 
> Fixes `opsx:explore` to be truly interactive by removing `--pipeline`/`-t` (in root `package.json`, installer script defaults, and installer help text), and updates the documented project structure to include `scripts/opsx-cli.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e34d3f6e19061aaa9834b12b8d86cd2b9e0510d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->