### PR TITLE
docs: add OpenSpec reference to SDD tool lists in README (en/ja)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -324,3 +324,4 @@ scripts/
 
 - [Kiro](https://github.com/kirodotdev/Kiro) - Amazon による SDD ベースの AI 開発環境
 - [cc-sdd](https://github.com/gotalab/cc-sdd) - 複数の AI コーディングエージェントに対応した SDD ツール
+- [OpenSpec](https://github.com/Fission-AI/OpenSpec) - AI コーディングアシスタント向け軽量 SDD フレームワーク

--- a/README.md
+++ b/README.md
@@ -324,3 +324,4 @@ This project is inspired by the following projects:
 
 - [Kiro](https://github.com/kirodotdev/Kiro) - Amazon's SDD-based AI development environment
 - [cc-sdd](https://github.com/gotalab/cc-sdd) - SDD tool supporting multiple AI coding agents
+- [OpenSpec](https://github.com/Fission-AI/OpenSpec) - Lightweight spec-driven framework for AI coding assistants


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code or behavior is modified.
> 
> **Overview**
> Adds an `OpenSpec` reference/link to the *Inspired By* section in both `README.md` and `README.ja.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 593fa55ff17502c0c7a41179fa54d602749dc5e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->