### PR TITLE
feat: edit=false/supervise/CI責任配置に関するSKILL.mdのガイドライン追加

### DIFF
--- a/.agent/skills/takt-analyze/SKILL.md
+++ b/.agent/skills/takt-analyze/SKILL.md
@@ -41,6 +41,9 @@ description: >
 | セクションマップ整合性 | セクションマップのキーとムーブメント内参照が一致するか | Critical |
 | ファイルパス存在 | セクションマップのパスが実在するか | Critical |
 | parallel構造 | 親ルールが`all()`/`any()`を使用、サブステップに`next`がないか | Warning |
+| edit=false + ビルド操作 | `edit: false` のムーブメントのインストラクションがビルドコマンド（`cargo check` 等）の禁止を明示しているか。読み取り専用サンドボックスでビルドは `Operation not permitted` で失敗する | Warning |
+| supervise失敗の遷移先 | `supervise` の失敗ルールが `plan` に遷移していないか。修正可能な問題は `fix` へ遷移すべきで、`supervise → plan` は根本設計変更が必要な場合のみ | Warning |
+| CI実行の責任配置 | `supervise`/`ai_review` 等の `edit: false` ムーブメントのインストラクションがCIの直接実行を禁止し、`fix`/`implement` のレポート証跡確認のみを求めているか | Warning |
 | edit権限 | `edit: true`のムーブメントに適切な`required_permission_mode`があるか | Info |
 | session設定 | 実装系ムーブメントに`session: refresh`があるか | Info |
 

--- a/.agent/skills/takt-optimize/SKILL.md
+++ b/.agent/skills/takt-optimize/SKILL.md
@@ -142,9 +142,12 @@ movements:
 | threshold調整 | 閾値が高すぎる/低すぎる場合に適正値を提案 |
 | ABORT条件追加 | 失敗時のABORT遷移がない場合に追加 |
 | max_movements調整 | ムーブメント数に対してmax_movementsが過大/過小な場合に調整 |
+| supervise失敗遷移の修正 | `supervise` 失敗時に `plan` へ遷移するルールを `fix` に変更する。`supervise → plan` ループは高コストで非生産的になりやすい |
+| edit=false ビルド禁止の追記 | `edit: false` のムーブメントが参照するインストラクションに「ビルドコマンドを実行しないこと」の禁止セクション（`## やらないこと`）を追加する |
 
 **threshold推奨値:**
 - review→fix サイクル: 3回
+- supervise→fix サイクル: 3回
 - implement→test サイクル: 2回
 
 ### 6. 並列化提案

--- a/.agent/skills/takt-piece/SKILL.md
+++ b/.agent/skills/takt-piece/SKILL.md
@@ -146,6 +146,9 @@ movements:
 | `session: refresh` | 実装系ムーブメントで新規セッション開始 |
 | `pass_previous_response: false` | レビュー結果を直接読ませたくない場合 |
 | `required_permission_mode` | edit権限が必要な場合に `edit` を指定 |
+| `edit: false` + ビルド操作 | `edit: false` のムーブメントは読み取り専用サンドボックスで動作するため、コンパイル・ビルドを伴うコマンド（`cargo check` 等）を実行させてはいけない。インストラクションに「## やらないこと」セクションで明示的に禁止する |
+| CI実行責任の配置 | ビルドを伴うCIは `edit: true` の `fix`/`implement` ムーブメントで実行しレポートに記録する。`supervise` 等の `edit: false` ムーブメントはレポート証跡の確認のみ行い、CI自身は実行しない |
+| `supervise` の失敗遷移 | 修正で解決できる問題なら `fix` へ遷移させる。`plan` は根本的な設計変更が必要な場合のみ。`supervise → plan` の安易な遷移はループの原因になる |
 
 #### ルール設計
 


### PR DESCRIPTION
## 概要

`edit: false` ムーブメントのビルド操作禁止、`supervise` の失敗遷移設計、CI実行責任の配置に関するチェック項目と設計ガイドラインを各スキルの SKILL.md に追加した。

## 変更内容

### takt-analyze
検証チェックリストに以下を追加：
- **edit=false + ビルド操作**: `edit: false` のムーブメントのインストラクションがビルドコマンド（`cargo check` 等）の禁止を明示しているかチェック（読み取り専用サンドボックスではビルドが `Operation not permitted` で失敗するため）
- **supervise失敗の遷移先**: `supervise` の失敗ルールが `plan` に遷移していないかチェック（修正可能な問題は `fix` へ遷移すべき）
- **CI実行の責任配置**: `edit: false` ムーブメントのインストラクションがCIの直接実行を禁止し、`fix`/`implement` のレポート証跡確認のみを求めているかチェック

### takt-optimize
最適化パターンに以下を追加：
- **supervise失敗遷移の修正**: `supervise` 失敗時に `plan` へ遷移するルールを `fix` に変更（`supervise → plan` ループは高コストで非生産的）
- **edit=false ビルド禁止の追記**: `edit: false` のムーブメントが参照するインストラクションに「ビルドコマンドを実行しないこと」の禁止セクションを追加

### takt-piece
設計ガイドライン（注意事項テーブル）に以下を追加：
- **`edit: false` + ビルド操作**: 読み取り専用サンドボックスではコンパイル・ビルドを伴うコマンドを実行させてはいけない旨を明示
- **CI実行責任の配置**: ビルドを伴うCIは `edit: true` の `fix`/`implement` で実行し、`supervise` 等はレポート証跡確認のみ行う設計指針
- **`supervise` の失敗遷移**: 修正で解決できる問題は `fix` へ遷移させ、`plan` は根本設計変更が必要な場合のみとする設計指針

## 背景

`edit: false` ムーブメントが読み取り専用サンドボックスで動作する際にビルドコマンドを実行しようとして失敗するケースや、`supervise → plan` の遷移ループによる高コスト化の問題が実運用で確認された。これらの知見をスキルのガイドラインに反映する。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> ドキュメント（SKILL.md）のみの変更で実行コードやワークフロー定義自体は変更しないため低リスク。運用ガイドの追加により既存のチーム慣習と齟齬が出る可能性はある。
> 
> **Overview**
> **TAKTの3スキル（`takt-analyze`/`takt-optimize`/`takt-piece`）のガイドラインを拡充**し、読み取り専用の `edit: false` ムーブメントでの落とし穴を明文化します。
> 
> `edit: false` ではビルド/コンパイル系コマンド（例: `cargo check`）を明示的に禁止するチェック/追記指針を追加し、CI実行は `fix`/`implement` など *編集可能ムーブメント側* に寄せて証跡（レポート）確認に限定する方針を追記します。併せて、`supervise` の失敗時に安易に `plan` へ戻さず、修正可能なら `fix` へ遷移させるべき、というチェック項目と最適化パターンを追加します。
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99a67ddd2f00e37286e1e2e06c3758259f8dbd74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->