### PR TITLE
fix(ci): add git pull --rebase before push in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
           PAT: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
           git remote set-url origin https://x-access-token:${PAT}@github.com/${{ github.repository }}.git
+          git pull --rebase origin ${GITHUB_REF_NAME}
           git push origin HEAD:${GITHUB_REF_NAME}
           git push origin ${{ steps.changelog.outputs.tag }}
 


### PR DESCRIPTION
Prevents non-fast-forward rejection when remote main advances during the release workflow execution (e.g. by tokei or other workflows).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; it only affects the release workflow’s git push behavior and could at worst cause the workflow to fail if rebase conflicts occur.
> 
> **Overview**
> Prevents non-fast-forward push failures in `.github/workflows/release.yml` by pulling the latest branch state with `git pull --rebase origin ${GITHUB_REF_NAME}` immediately before pushing the release commit and tag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eef19823dfbbadb2d303c1eea71fbf225d4ae9a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->