### PR TITLE
chore(deps): bump `@fission-ai/openspec` to 1.4.0 in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
 node = "24"
 python = "3"
-"npm:@fission-ai/openspec" = "1.3.1"
+"npm:@fission-ai/openspec" = "1.4.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single dev-tool version pin with no application or runtime code changes.
> 
> **Overview**
> Bumps the **mise**-managed **`@fission-ai/openspec`** npm tool from **1.3.0** to **1.4.0** in `mise.toml`, so local/dev environments install the newer CLI when mise syncs tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08424df8df406586f989af92112375dd2b6fb7de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->