### PR TITLE
docs: clarify Kiro roadmap marker semantics

### DIFF
--- a/.takt/en/facets/instructions/kiro-cross-spec-review.md
+++ b/.takt/en/facets/instructions/kiro-cross-spec-review.md
@@ -17,7 +17,7 @@ Review generated specs after batch worker dispatch. Focus on cross-spec consiste
 - Generated `.kiro/specs/*/design.md` as primary architecture input.
 - Generated `.kiro/specs/*/requirements.md` for scope and acceptance criteria.
 - Generated `.kiro/specs/*/tasks.md` for `_Boundary:_` annotations.
-- Worker feature results and skipped completed specs from `kiro-spec-batch`.
+- Worker feature results and skipped spec-ready entries from `kiro-spec-batch`.
 
 ## Review Checks
 

--- a/.takt/en/facets/instructions/kiro-discovery.md
+++ b/.takt/en/facets/instructions/kiro-discovery.md
@@ -26,8 +26,10 @@ Classify a user work request into one Kiro discovery `actionPath` and decide whe
 3. For `EXISTING_SPEC_UPDATE` and `DIRECT_IMPLEMENTATION`, do not write new discovery artifacts. Return a concrete `nextAction`.
 4. For `SINGLE_SPEC`, plan or write `.kiro/specs/<feature>/brief.md`.
 5. For `MULTI_SPEC` and `MIXED_DECOMPOSITION`, plan or write `.kiro/steering/roadmap.md` and each new spec `brief.md`.
-6. For `MIXED_DECOMPOSITION`, keep existing spec updates and direct implementation candidates as `awarenessOnlyItems`.
-7. If the action path or boundary ownership is ambiguous, return `blockingReason` and keep `createdFiles` empty.
+6. Roadmap checklist markers represent spec readiness only. Keep new or unapproved specs as `[ ]`; use `[x]` only when `spec.json.phase == "tasks-generated"`, requirements/design/tasks approvals, `ready_for_implementation == true`, and required artifact existence are confirmed.
+7. Read implementation progress from task checkboxes in `.kiro/specs/<feature>/tasks.md`; do not infer implementation completion from roadmap markers.
+8. For `MIXED_DECOMPOSITION`, keep existing spec updates and direct implementation candidates as `awarenessOnlyItems`.
+9. If the action path or boundary ownership is ambiguous, return `blockingReason` and keep `createdFiles` empty.
 
 ## Brief Artifact Structure
 

--- a/.takt/en/facets/instructions/kiro-spec-batch.md
+++ b/.takt/en/facets/instructions/kiro-spec-batch.md
@@ -15,14 +15,16 @@ Run `kiro-spec-batch` as a dependency-wave controller for `.kiro/steering/roadma
 
 - `.kiro/steering/roadmap.md` with `## Specs (dependency order)`.
 - Optional awareness-only sections: `## Existing Spec Updates` and `## Direct Implementation Candidates`.
-- `.kiro/specs/<feature>/brief.md` for every pending batch feature.
+- `.kiro/specs/<feature>/brief.md` for every spec-pending batch feature.
 - `kiro-spec-generation-workflows` phase contract and lifecycle result fields.
 
 ## Wave Planning
 
-- Parse pending specs and skipped completed specs from `## Specs (dependency order)`.
-- Build strict dependency waves. A feature can enter a wave only when every dependency is completed or belongs to an earlier wave.
-- Report missing dependency, circular dependency, missing `brief.md`, and unknown completion markers before worker dispatch.
+- Parse spec-pending entries and skipped spec-ready entries from `## Specs (dependency order)`.
+- Treat roadmap `[x]` as a spec ready marker, not as implementation completion or `tasks.md` checkbox completion.
+- Build strict dependency waves. A feature can enter a wave only when every dependency is spec ready or belongs to an earlier wave.
+- Do not skip solely because `tasks.md` exists. Confirm readiness evidence from `spec.json.phase == "tasks-generated"`, requirements/design/tasks approvals, `ready_for_implementation == true`, and required artifact existence.
+- Report missing dependency, circular dependency, missing `brief.md`, and unknown readiness markers before worker dispatch.
 
 ## Dynamic Worker Dispatch
 

--- a/.takt/en/facets/output-contracts/kiro-batch-summary.md
+++ b/.takt/en/facets/output-contracts/kiro-batch-summary.md
@@ -5,7 +5,7 @@
 ## Machine Fields
 
 - `wavePlan`: dependency waves built from `## Specs (dependency order)`.
-- `skippedCompleted`: completed roadmap specs skipped by the batch.
+- `skippedSpecReady`: spec-ready roadmap entries skipped by the batch.
 - `featureResults`: array of worker results with `feature`, `status`, `generatedArtifacts`, `blockingReason`, and `nextAction`.
 - `failedFeatures`: array of features that ended in `BLOCKED`, `NEEDS_FIX`, or worker failure.
 - `awarenessOnlyItems`: existing spec updates and direct implementation candidates excluded from worker dispatch.

--- a/.takt/en/facets/policies/kiro-roadmap-dependency-waves.md
+++ b/.takt/en/facets/policies/kiro-roadmap-dependency-waves.md
@@ -20,7 +20,27 @@ Only `## Specs (dependency order)` is authoritative for `kiro-spec-batch` wave e
 - [ ] downstream-feature -- One-line description. Dependencies: feature-name
 ```
 
-`Dependencies: none` means the feature can enter the first wave unless it is already complete.
+`Dependencies: none` means the feature can enter the first wave when it is spec pending.
+
+## Roadmap Marker Semantics
+
+Roadmap checklist markers represent spec readiness. They must not represent implementation completion.
+
+- `[x]` is the spec ready marker. Use it only when all of this evidence is true:
+  - `spec.json.phase == "tasks-generated"`
+  - `approvals.requirements.generated == true`
+  - `approvals.requirements.approved == true`
+  - `approvals.design.generated == true`
+  - `approvals.design.approved == true`
+  - `approvals.tasks.generated == true`
+  - `approvals.tasks.approved == true`
+  - `ready_for_implementation == true`
+  - `.kiro/specs/<feature>/requirements.md` exists
+  - `.kiro/specs/<feature>/design.md` exists
+  - `.kiro/specs/<feature>/tasks.md` exists
+- `[ ]` is the spec not ready / spec pending marker.
+- Read implementation progress from task checkboxes in `.kiro/specs/<feature>/tasks.md`, not from roadmap markers.
+- Roadmap markers do not represent implementation completion. The mere existence of `tasks.md` must not mark a roadmap entry `[x]`.
 
 ## Awareness-Only Sections
 
@@ -39,6 +59,6 @@ These sections can affect review context and sequencing advice, but they are not
 - Duplicate dependency-order feature names block batch execution as `duplicate roadmap spec entry`.
 - Missing dependency names block batch execution.
 - `circular dependency` blocks batch execution.
-- Unknown completion markers block batch execution.
+- Unknown readiness markers block batch execution.
 - Pending specs without `.kiro/specs/<feature>/brief.md` block worker dispatch.
-- Empty, invalid, or duplicate roadmap parse states must not be treated as `all roadmap specs already complete`.
+- Empty, invalid, or duplicate roadmap parse states must not be treated as `all roadmap specs spec-ready`.

--- a/.takt/en/workflows/kiro-spec-batch.yaml
+++ b/.takt/en/workflows/kiro-spec-batch.yaml
@@ -65,7 +65,7 @@ steps:
         next: finalize-batch
       - condition: dependency waves planned and pending feature count greater than zero
         next: dispatch-wave
-      - condition: all roadmap specs already complete and roadmap spec entries present
+      - condition: all roadmap specs spec-ready and roadmap spec entries present
         next: cross-spec-review
 
   - name: dispatch-wave

--- a/.takt/ja/facets/instructions/kiro-cross-spec-review.md
+++ b/.takt/ja/facets/instructions/kiro-cross-spec-review.md
@@ -17,7 +17,7 @@ batch worker dispatch 後の generated specs を review します。individual g
 - primary architecture input としての generated `.kiro/specs/*/design.md`。
 - scope と acceptance criteria 用の generated `.kiro/specs/*/requirements.md`。
 - `_Boundary:_` annotation 用の generated `.kiro/specs/*/tasks.md`。
-- `kiro-spec-batch` の worker feature results と skipped completed specs。
+- `kiro-spec-batch` の worker feature results と skipped spec-ready entries。
 
 ## Review Checks
 

--- a/.takt/ja/facets/instructions/kiro-discovery.md
+++ b/.takt/ja/facets/instructions/kiro-discovery.md
@@ -26,8 +26,10 @@ extends_skill_section: "## Step 2: Determine Action Path"
 3. `EXISTING_SPEC_UPDATE` と `DIRECT_IMPLEMENTATION` では新しい discovery artifact を書かず、具体的な `nextAction` を返す。
 4. `SINGLE_SPEC` では `.kiro/specs/<feature>/brief.md` を計画または作成する。
 5. `MULTI_SPEC` と `MIXED_DECOMPOSITION` では `.kiro/steering/roadmap.md` と新規 spec ごとの `brief.md` を計画または作成する。
-6. `MIXED_DECOMPOSITION` では既存 spec 更新と direct implementation candidate を `awarenessOnlyItems` に分離する。
-7. action path または boundary ownership が曖昧な場合は、`blockingReason` を返し `createdFiles` を空に保つ。
+6. roadmap の checklist marker は spec readiness だけを表す。新規または未承認 spec は `[ ]` とし、`[x]` は `spec.json.phase == "tasks-generated"`、requirements/design/tasks approvals、`ready_for_implementation == true`、required artifacts の存在を確認できる場合だけ使う。
+7. implementation progress は `.kiro/specs/<feature>/tasks.md` の task checkbox で判断し、roadmap marker から実装完了を推定しない。
+8. `MIXED_DECOMPOSITION` では既存 spec 更新と direct implementation candidate を `awarenessOnlyItems` に分離する。
+9. action path または boundary ownership が曖昧な場合は、`blockingReason` を返し `createdFiles` を空に保つ。
 
 ## Brief Artifact Structure
 

--- a/.takt/ja/facets/instructions/kiro-spec-batch.md
+++ b/.takt/ja/facets/instructions/kiro-spec-batch.md
@@ -15,14 +15,16 @@ extends_skill_section: "## Step 2: Build Dependency Waves"
 
 - `## Specs (dependency order)` を持つ `.kiro/steering/roadmap.md`。
 - optional awareness-only sections: `## Existing Spec Updates` と `## Direct Implementation Candidates`。
-- pending batch feature ごとの `.kiro/specs/<feature>/brief.md`。
+- spec pending batch feature ごとの `.kiro/specs/<feature>/brief.md`。
 - `kiro-spec-generation-workflows` phase contract と lifecycle result fields。
 
 ## Wave Planning
 
-- `## Specs (dependency order)` から pending specs と skipped completed specs を解析する。
-- strict dependency waves を作る。feature はすべての dependency が完了済み、または earlier wave に属する場合だけ wave に入れる。
-- missing dependency、circular dependency、missing `brief.md`、unknown completion marker は worker dispatch 前に報告する。
+- `## Specs (dependency order)` から spec pending entries と skipped spec-ready entries を解析する。
+- roadmap の `[x]` は spec ready marker として扱い、implementation completion や `tasks.md` checkbox completion として扱わない。
+- strict dependency waves を作る。feature はすべての dependency が spec ready、または earlier wave に属する場合だけ wave に入れる。
+- `tasks.md` が存在するだけで skip しない。`spec.json.phase == "tasks-generated"`、requirements/design/tasks approval、`ready_for_implementation == true`、required artifacts の存在を readiness evidence として確認する。
+- missing dependency、circular dependency、missing `brief.md`、unknown readiness marker は worker dispatch 前に報告する。
 
 ## Dynamic Worker Dispatch
 

--- a/.takt/ja/facets/output-contracts/kiro-batch-summary.md
+++ b/.takt/ja/facets/output-contracts/kiro-batch-summary.md
@@ -5,7 +5,7 @@
 ## Machine Fields
 
 - `wavePlan`: `## Specs (dependency order)` から作った dependency waves。
-- `skippedCompleted`: batch が skip した completed roadmap specs。
+- `skippedSpecReady`: batch が skip した spec-ready roadmap entries。
 - `featureResults`: `feature`、`status`、`generatedArtifacts`、`blockingReason`、`nextAction` を持つ worker result 配列。
 - `failedFeatures`: `BLOCKED`、`NEEDS_FIX`、worker failure で終わった feature 配列。
 - `awarenessOnlyItems`: worker dispatch から除外した既存 spec 更新と direct implementation candidates。

--- a/.takt/ja/facets/policies/kiro-roadmap-dependency-waves.md
+++ b/.takt/ja/facets/policies/kiro-roadmap-dependency-waves.md
@@ -20,7 +20,27 @@
 - [ ] downstream-feature -- One-line description. Dependencies: feature-name
 ```
 
-`Dependencies: none` は、その feature が未完了なら最初の wave に入れることを意味します。
+`Dependencies: none` は、その feature が spec pending なら最初の wave に入れることを意味します。
+
+## Roadmap Marker Semantics
+
+roadmap の checklist marker は spec readiness を表す。implementation completion を表してはいけない。
+
+- `[x]` は spec ready marker である。次の evidence がすべて成り立つ場合だけ使う:
+  - `spec.json.phase == "tasks-generated"`
+  - `approvals.requirements.generated == true`
+  - `approvals.requirements.approved == true`
+  - `approvals.design.generated == true`
+  - `approvals.design.approved == true`
+  - `approvals.tasks.generated == true`
+  - `approvals.tasks.approved == true`
+  - `ready_for_implementation == true`
+  - `.kiro/specs/<feature>/requirements.md` が存在する
+  - `.kiro/specs/<feature>/design.md` が存在する
+  - `.kiro/specs/<feature>/tasks.md` が存在する
+- `[ ]` は spec not ready / spec pending marker である。
+- implementation progress は roadmap marker ではなく `.kiro/specs/<feature>/tasks.md` の task checkbox を読む。
+- roadmap marker は implementation completion を表さない。`tasks.md` が存在するだけで `[x]` にしてはいけない。
 
 ## Awareness-Only Sections
 
@@ -39,6 +59,6 @@ roadmap には次の section を context として置けるが、これらは aw
 - dependency-order feature name が重複する場合は `duplicate roadmap spec entry` として batch execution を止める。
 - missing dependency name は batch execution を止める。
 - `circular dependency` は batch execution を止める。
-- unknown completion marker は batch execution を止める。
+- unknown readiness marker は batch execution を止める。
 - pending spec に `.kiro/specs/<feature>/brief.md` がない場合は worker dispatch 前に止める。
-- empty, invalid, duplicate の roadmap parse state を `all roadmap specs already complete` として扱ってはいけない。
+- empty, invalid, duplicate の roadmap parse state を `all roadmap specs spec-ready` として扱ってはいけない。

--- a/.takt/ja/workflows/kiro-spec-batch.yaml
+++ b/.takt/ja/workflows/kiro-spec-batch.yaml
@@ -65,7 +65,7 @@ steps:
         next: finalize-batch
       - condition: dependency waves planned and pending feature count greater than zero
         next: dispatch-wave
-      - condition: all roadmap specs already complete and roadmap spec entries present
+      - condition: all roadmap specs spec-ready and roadmap spec entries present
         next: cross-spec-review
 
   - name: dispatch-wave

--- a/scripts/validate-kiro-discovery-batch-workflows.mjs
+++ b/scripts/validate-kiro-discovery-batch-workflows.mjs
@@ -63,7 +63,7 @@ const facetSpecs = [
     parent: "plan",
     skill: "kiro-discovery",
     skillSection: "## Step 2: Determine Action Path",
-    terms: ["brief.md", ".kiro/steering/roadmap.md", "blockingReason", ...actionPathEnums],
+    terms: ["brief.md", ".kiro/steering/roadmap.md", "blockingReason", "ready_for_implementation", ...actionPathEnums],
   },
   {
     kind: "instructions",
@@ -71,7 +71,7 @@ const facetSpecs = [
     parent: "supervise",
     skill: "kiro-spec-batch",
     skillSection: "## Step 2: Build Dependency Waves",
-    terms: ["dependency wave", "dynamic subagent dispatch", "kiro-spec-generation-workflows", "feature result"],
+    terms: ["dependency wave", "dynamic subagent dispatch", "kiro-spec-generation-workflows", "feature result", "spec ready"],
   },
   {
     kind: "instructions",
@@ -91,7 +91,15 @@ const facetSpecs = [
     kind: "policies",
     file: "kiro-roadmap-dependency-waves.md",
     parent: "task-decomposition",
-    terms: ["## Specs (dependency order)", "Existing Spec Updates", "Direct Implementation Candidates", "circular dependency"],
+    terms: [
+      "## Specs (dependency order)",
+      "Existing Spec Updates",
+      "Direct Implementation Candidates",
+      "circular dependency",
+      "spec.json.phase == \"tasks-generated\"",
+      "ready_for_implementation == true",
+      "implementation progress",
+    ],
   },
   {
     kind: "policies",
@@ -109,7 +117,7 @@ const facetSpecs = [
     kind: "output-contracts",
     file: "kiro-batch-summary.md",
     parent: "validation",
-    terms: ["wavePlan", "featureResults", "failedFeatures", "crossSpecReview", "implementationReady"],
+    terms: ["wavePlan", "skippedSpecReady", "featureResults", "failedFeatures", "crossSpecReview", "implementationReady"],
   },
   {
     kind: "output-contracts",
@@ -370,7 +378,7 @@ function parseRoadmapLine(line) {
     dependencies: match[4].trim().toLowerCase() === "none"
       ? []
       : match[4].split(",").map((dependency) => dependency.trim()).filter(Boolean),
-    status: match[1].toLowerCase() === "x" ? "done" : "pending",
+    status: match[1].toLowerCase() === "x" ? "ready" : "pending",
   };
 }
 
@@ -445,23 +453,23 @@ export function buildDependencyWaves(specs) {
     }
   }
   if (errors.length > 0) {
-    return { ok: false, waves: [], skippedCompleted: [], errors };
+    return { ok: false, waves: [], skippedSpecReady: [], errors };
   }
 
-  const completed = new Set(specs.filter((spec) => spec.status === "done").map((spec) => spec.featureName));
+  const specReady = new Set(specs.filter((spec) => spec.status === "ready").map((spec) => spec.featureName));
   const pending = new Set(specs.filter((spec) => spec.status === "pending").map((spec) => spec.featureName));
   const waves = [];
 
   while (pending.size > 0) {
     const current = [...pending].filter((featureName) => {
       const spec = byName.get(featureName);
-      return spec.dependencies.every((dependency) => completed.has(dependency));
+      return spec.dependencies.every((dependency) => specReady.has(dependency));
     });
     if (current.length === 0) {
       return {
         ok: false,
         waves,
-        skippedCompleted: [...completed],
+        skippedSpecReady: [...specReady],
         errors: [`circular dependency among pending specs: ${[...pending].sort().join(", ")}`],
       };
     }
@@ -469,14 +477,14 @@ export function buildDependencyWaves(specs) {
     waves.push({ waveNumber: waves.length + 1, featureNames: current });
     for (const featureName of current) {
       pending.delete(featureName);
-      completed.add(featureName);
+      specReady.add(featureName);
     }
   }
 
   return {
     ok: true,
     waves,
-    skippedCompleted: specs.filter((spec) => spec.status === "done").map((spec) => spec.featureName).sort(),
+    skippedSpecReady: specs.filter((spec) => spec.status === "ready").map((spec) => spec.featureName).sort(),
     errors: [],
   };
 }

--- a/tests/kiro-discovery-batch-workflows.test.mjs
+++ b/tests/kiro-discovery-batch-workflows.test.mjs
@@ -66,7 +66,7 @@ test("roadmap parser separates dependency-order specs from awareness-only sectio
   assert.deepEqual(
     result.specs.map((spec) => [spec.featureName, spec.status, spec.dependencies]),
     [
-      ["foundation", "done", []],
+      ["foundation", "ready", []],
       ["feature-a", "pending", ["foundation"]],
       ["feature-b", "pending", ["foundation"]],
       ["feature-c", "pending", ["feature-a", "feature-b"]],
@@ -115,17 +115,17 @@ test("roadmap parser rejects duplicate dependency-order features", () => {
     "# Roadmap",
     "",
     "## Specs (dependency order)",
-    "- [x] feature-a -- Existing completion. Dependencies: none",
+    "- [x] feature-a -- Existing spec-ready entry. Dependencies: none",
     "- [ ] feature-a -- Duplicate pending entry. Dependencies: none",
   ].join("\n");
 
   const result = parseRoadmap(roadmap);
   const wavePlan = buildDependencyWaves([
-    { featureName: "feature-a", description: "Existing completion", dependencies: [], status: "done" },
+    { featureName: "feature-a", description: "Existing spec-ready entry", dependencies: [], status: "ready" },
     { featureName: "feature-a", description: "Duplicate pending entry", dependencies: [], status: "pending" },
   ]);
 
-  assert.deepEqual(result.specs.map((spec) => spec.status), ["done"]);
+  assert.deepEqual(result.specs.map((spec) => spec.status), ["ready"]);
   assert.ok(result.errors.some((error) => error.includes("duplicate roadmap spec entry: feature-a")));
   assert.equal(wavePlan.ok, false);
   assert.ok(wavePlan.errors.some((error) => error.includes("duplicate roadmap spec entry: feature-a")));
@@ -191,13 +191,13 @@ test("validation reports roadmap missing dependencies once", () => {
 test("batch plan prerequisites reject pending specs without brief", () => {
   const root = makeFixture();
   const result = validateBatchPlanPrerequisites(root, [
-    { featureName: "done-feature", description: "Done", dependencies: [], status: "done" },
+    { featureName: "ready-feature", description: "Spec ready", dependencies: [], status: "ready" },
     { featureName: "pending-feature", description: "Pending", dependencies: [], status: "pending" },
   ]);
 
   assert.equal(result.ok, false);
   assert.ok(result.errors.some((error) => error.includes(".kiro/specs/pending-feature/brief.md")));
-  assert.equal(result.errors.some((error) => error.includes("done-feature")), false);
+  assert.equal(result.errors.some((error) => error.includes("ready-feature")), false);
 });
 
 test("batch plan prerequisites accept pending specs with brief", () => {
@@ -409,7 +409,20 @@ test("roadmap dependency wave policy keeps awareness-only sections out of batch 
       "missing roadmap spec entries",
       "invalid roadmap spec entry",
       "duplicate roadmap spec entry",
-      "all roadmap specs already complete",
+      "all roadmap specs spec-ready",
+      "spec.json.phase == \"tasks-generated\"",
+      "approvals.requirements.generated == true",
+      "approvals.requirements.approved == true",
+      "approvals.design.generated == true",
+      "approvals.design.approved == true",
+      "approvals.tasks.generated == true",
+      "approvals.tasks.approved == true",
+      "ready_for_implementation == true",
+      ".kiro/specs/<feature>/requirements.md",
+      ".kiro/specs/<feature>/design.md",
+      ".kiro/specs/<feature>/tasks.md",
+      "implementation progress",
+      "task checkbox",
     ]) {
       assert.ok(policy.includes(term), `${policyPath} should include ${term}`);
     }
@@ -453,20 +466,20 @@ test("kiro-spec-batch workflow uses dynamic worker dispatch without workflow reu
       `${workflowPath} should not allow parsed roadmap to bypass missing brief checks`,
     );
     assert.equal(
-      workflow.includes("condition: all roadmap specs already complete\n"),
+      workflow.includes("condition: all roadmap specs spec-ready\n"),
       false,
-      `${workflowPath} should not route empty roadmaps as already complete`,
+      `${workflowPath} should not route empty roadmaps as spec-ready`,
     );
-    assert.ok(workflow.includes("condition: all roadmap specs already complete and roadmap spec entries present"));
+    assert.ok(workflow.includes("condition: all roadmap specs spec-ready and roadmap spec entries present"));
     assert.ok(workflow.includes("verdict PASS"));
     assert.ok(workflow.includes("verdict NEEDS_FIX"));
     assert.ok(workflow.includes("verdict DECOMPOSITION_RETURN"));
     assert.equal(workflow.includes("condition: DECOMPOSITION_RETURN or loop_monitors.threshold reached"), false);
     assert.equal(workflow.includes("crossSpecReview PASS"), false);
     assert.ok(
-      workflow.indexOf("condition: all roadmap specs already complete and roadmap spec entries present") <
+      workflow.indexOf("condition: all roadmap specs spec-ready and roadmap spec entries present") <
         workflow.indexOf("condition: verdict PASS"),
-      `${workflowPath} should route already-complete roadmaps through cross-spec review before finalization`,
+      `${workflowPath} should route spec-ready roadmaps through cross-spec review before finalization`,
     );
     assert.equal(/\btakt\s+-w\b|\btakt\s+.*\s-w\s+/.test(workflow), false);
     assert.equal(workflow.includes("workflow_call"), false);
@@ -514,6 +527,7 @@ test("batch summary contract separates worker results from implementation readin
     const content = readFileSync(join(repoRoot, path), "utf8");
     for (const term of [
       "wavePlan",
+      "skippedSpecReady",
       "featureResults",
       "failedFeatures",
       "awarenessOnlyItems",


### PR DESCRIPTION
## Summary
- Clarify that roadmap `[x]` means spec-ready, not implementation-complete
- Define spec-ready in terms of generated/approved artifacts and `ready_for_implementation`
- Update Kiro batch/discovery wording to avoid confusing roadmap markers with task progress
- Keep upstream-copied `.agents/skills/kiro-*` unchanged

## Verification
- `rg` checked roadmap marker wording across Kiro workflow guidance
- `npm run validate:kiro-discovery-batch-workflows`
- `npm run test:kiro-discovery-batch-workflows`
- `npm run validate:kiro-shared-contracts`
- `npm run test:kiro-shared-contracts`
- `npm run validate:kiro-workflow-surface`
- `npm run test:kiro-workflow-surface`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, workflow guidance, and validation/parser renames only; no runtime product logic or auth/data paths changed.
> 
> **Overview**
> **Redefines Kiro roadmap checklist semantics** so `[x]` means **spec-ready** (approved requirements/design/tasks and `ready_for_implementation`), not implementation done. Implementation progress stays on `tasks.md` checkboxes only.
> 
> **Discovery, batch, and cross-spec review** (en/ja) now use **spec-pending** / **spec-ready** wording, require evidence before skipping batch work (not merely `tasks.md` existing), and rename batch output **`skippedCompleted` → `skippedSpecReady`**. The **`kiro-spec-batch`** workflow routes to cross-spec review when **all roadmap specs are spec-ready** (not “already complete”).
> 
> **`kiro-roadmap-dependency-waves`** adds an explicit **Roadmap Marker Semantics** section with the `[x]` evidence checklist. **`validate-kiro-discovery-batch-workflows.mjs`** parses `[x]` as `ready` (not `done`) and builds waves from spec-ready dependencies; tests and facet term checks were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812e627798c5ba19afe596627a0314cce5bffe00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->