### PR TITLE
chore: restore Kiro requirements skill heading

### DIFF
--- a/.agents/skills/kiro-spec-requirements/SKILL.md
+++ b/.agents/skills/kiro-spec-requirements/SKILL.md
@@ -64,7 +64,7 @@ After all research completes, synthesize findings in main context before generat
    - If scope could be misread, add lightweight boundary context without introducing implementation or architecture ownership detail
    - Keep this as a draft until the review gate passes; do not write `requirements.md` yet
 
-### Step 4: Review Requirements Draft
+4. **Review Requirements Draft**:
    - Run the `Requirements Review Gate` from `rules/requirements-review-gate.md`
    - Review coverage, EARS compliance, ambiguity, adjacent expectations, and scope boundaries before finalizing
    - If issues are local to the draft, repair the requirements and review again


### PR DESCRIPTION
## Summary
- Restore the `kiro-spec-requirements` agent skill review step heading to the upstream numbered-list format
- Keep TAKT-owned facets and `.kiro/settings` templates unchanged

## Verification
- `git diff --check`
- `npm run validate:kiro-shared-contracts`
- `npm run validate:kiro-spec-generation-workflows` *(fails on existing `kiro-spec-batch.md` ja/en language parity: missing `approvals`; unrelated to this one-line skill heading restore)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line documentation formatting in an agent skill; no runtime or contract behavior changes.
> 
> **Overview**
> Restores **step 4** in the `kiro-spec-requirements` agent skill from a standalone `### Step 4:` heading back to the same **numbered-list** style as the other execution steps (`4. **Review Requirements Draft**:`). No workflow, rules, or TAKT-owned content changes—formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1ea6b723d24a243f7a9f94dfc53d138f71b87f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->