### PR TITLE
[codex] Add discovery AI quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
           npm run validate:kiro-spec-generation-workflows
           npm run validate:kiro-status-validation-workflows
           npm run test:kiro-ai-quality-gate-runtime-smoke
+          npm run test:kiro-discovery-ai-quality-gate-runtime-smoke
 
       - name: Validate workflows (ja)
         run: |

--- a/.kiro/specs/kiro-ai-quality-gate-workflow-coverage/design.md
+++ b/.kiro/specs/kiro-ai-quality-gate-workflow-coverage/design.md
@@ -2,15 +2,16 @@
 
 ## Overview
 
-この機能は TAKT Kiro workflow maintainer に、PR #90 で確立した AI quality gate 契約を Kiro workflow 群へ安全に横展開するための分類、generation-scoped gate、検証基盤を提供する。対象は `.takt/{en,ja}/workflows/kiro-*` と関連 facet / validator / test であり、`cc-sdd-*`、`opsx-*`、OpenSpec-compatible workflow は対象にしない。
+この機能は TAKT Kiro workflow maintainer に、PR #90 で確立した AI quality gate 契約を Kiro workflow 群へ安全に横展開するための coverage inventory、scoped callable gate、validator-backed contract を提供する。対象は `.takt/{en,ja}/workflows/kiro-*` と関連 facet / validator / test であり、`cc-sdd-*`、`opsx-*`、OpenSpec-compatible workflow は対象にしない。
 
-主な変更は、全 Kiro workflow を coverage category に分類し、artifact draft を生成または修正する spec generation workflow にだけ AI antipattern review / fix gate を追加することである。read-only validation/status workflow は read-only のまま維持し、orchestration workflow は downstream generation workflow への委譲を明示する。
+主な変更は、spec generation draft と discovery-owned artifact を別々の責任境界で gate することである。`kiro-spec-requirements/design/tasks/quick` は generation-scoped gate、`kiro-discovery` は discovery artifact gate を通す。read-only validation/status workflow は read-only のまま維持し、`kiro-spec-batch` は worker generation workflows へ artifact-level AI review を委譲する。
 
 ### Goals
 
 - 全 `.takt/{en,ja}/workflows/kiro-*` に対して AI quality gate coverage category を定義し、未分類を validator failure にする。
-- `kiro-spec-requirements`、`kiro-spec-design`、`kiro-spec-tasks`、`kiro-spec-quick` の generation draft を domain review / finalize 前に generation-scoped AI quality gate へ通す。
-- PR #90 の 6 点契約を callable gate caller と downstream review/finalize に対して validator と smoke test で検出可能にする。
+- `kiro-spec-requirements`、`kiro-spec-design`、`kiro-spec-tasks`、`kiro-spec-quick` の generated draft を domain review / finalize 前に generation-scoped AI quality gate へ通す。
+- `kiro-discovery` が `brief.md` または roadmap artifact を書いた場合、`report-discovery` 前に discovery-scoped AI quality gate を通す。
+- PR #90 の 6 点契約を implementation / spec generation / discovery gate caller に対して共有 validator と smoke test で検出可能にする。
 - en/ja workflow と facet の machine contract を揃え、upstream `.agents/skills/kiro-*` は直接変更しない。
 
 ### Non-Goals
@@ -18,7 +19,8 @@
 - `cc-sdd-*`、`opsx-*`、OpenSpec-compatible workflow への横展開。
 - upstream `.agents/skills/kiro-*` asset や `CC-SDD-CODEX.md` の直接修正。
 - `kiro-spec-status`、`kiro-validate-*` を edit-capable workflow に変えること。
-- `kiro-discovery` と `kiro-spec-batch` に artifact-level AI fix loop を追加すること。
+- `kiro-spec-batch` に direct artifact-level AI fix loop を追加すること。
+- `kiro-discovery` gate で requirements/design/tasks artifact、既存 spec の ownership、または implementation progress を直接修正すること。
 - roadmap checkbox marker を implementation progress として扱うこと。
 
 ## Boundary Commitments
@@ -26,25 +28,30 @@
 ### This Spec Owns
 
 - Kiro workflow AI quality gate coverage inventory の正本。
-- generation-scoped AI quality gate workflow と、その report semantics。
-- eligible generation caller workflow から generation-scoped gate への routing。
-- downstream generation review/finalize が AI gate evidence を消費するための facet 指示。
+- generation-scoped AI quality gate workflow と report semantics。
+- discovery-scoped AI quality gate workflow と report semantics。
+- eligible generation caller workflow から generation gate への routing。
+- `kiro-discovery` の artifact write 成功 path から discovery gate への routing と caller loop monitor。
+- downstream generation review/finalize と discovery report が AI gate evidence を消費するための facet 指示。
 - coverage inventory、allowed `workflow_call`、read-only exclusion、en/ja parity、runtime smoke を検証する validator/test。
 
 ### Out of Boundary
 
 - implementation gate 自体の仕様変更。ただし shared contract validation のため既存 `kiro-ai-quality-gate` と `kiro-impl` は read/validate 対象に含める。
-- discovery/batch の生成物に対する新しい AI review/fix ループ。これらは分類と委譲先記録のみを所有する。
+- `kiro-spec-batch` の worker orchestration、cross-spec review、remediation coordination の責務変更。
 - Kiro upstream skill asset の修正。TAKT workflow/facet/validator による実行時優先指示で補正する。
 - read-only workflow への修正 step、repair step、debug step、nested Kiro workflow call の追加。
+- discovery gate から `.kiro/specs/<feature>/requirements.md`、`design.md`、`tasks.md`、または implementation files へ越境する修正。
 
 ### Allowed Dependencies
 
 - `.takt/{en,ja}/workflows/kiro-ai-quality-gate.yaml` と `kiro-impl.yaml` の PR #90 契約。
+- `.takt/{en,ja}/workflows/kiro-spec-ai-quality-gate.yaml` の generation gate 契約。
 - TAKT workflow schema の `workflow_call`、`rules`、`loop_monitors`、facet composition。
 - built-in `ai-antipattern-reviewer` の routing vocabulary。
 - 既存 Kiro spec generation workflow の generate/review/repair/finalize 境界。
-- 既存 validators: `validate-kiro-shared-contracts.mjs`、`validate-kiro-spec-generation-workflows.mjs`、`validate-kiro-status-validation-workflows.mjs`、`validate-kiro-iterative-implementation-workflow.mjs`。
+- 既存 `kiro-discovery` の classify/plan/write/report 境界。
+- 既存 validators: `validate-kiro-shared-contracts.mjs`、`validate-kiro-ai-quality-gate-workflow-coverage.mjs`、`validate-kiro-spec-generation-workflows.mjs`、`validate-kiro-discovery-batch-workflows.mjs`、`validate-kiro-status-validation-workflows.mjs`。
 - Node.js built-in test runner と既存 npm scripts。
 
 ### Revalidation Triggers
@@ -52,6 +59,7 @@
 - built-in `ai-antipattern-reviewer` の routing vocabulary または report contract が変わる。
 - `workflow_call` の schema、relative path 解釈、または TAKT callable subworkflow 実行方式が変わる。
 - `.takt/{en,ja}/workflows/kiro-*` が追加、削除、名称変更される。
+- `kiro-discovery` の actionPath、plannedFiles、createdFiles、または `report-discovery` completion 条件が変わる。
 - `kiro-spec-quick` の no phase reuse ルールが変わる。
 - read-only validation/status workflow が write-capable な責務を持つように変わる。
 - gate report names、optional fix report semantics、loop monitor threshold semantics が変わる。
@@ -62,25 +70,24 @@
 
 `kiro-impl` は `execute-task -> ai-quality-gate -> review-task` の callable subworkflow 構造を持つ。PR #90 で、relative `workflow_call`、built-in review vocabulary、catch-all routing、optional fix report、loop exhaustion の replan routing、caller loop monitor への gate step 追加が runtime wiring 上の重要契約になった。
 
-spec generation workflows は generate/review/repair/finalize を分け、draft generation と lifecycle promotion を分離している。この設計ではその既存境界を維持し、draft が domain review に入る前に AI-specific quality gate を挟む。`kiro-spec-quick` は standalone phase workflow reuse を避ける既存設計なので、許可する `workflow_call` は generation-scoped AI gate に限定する。
+spec generation workflows は generate/review/repair/finalize を分け、draft generation と lifecycle promotion を分離している。既存実装は `kiro-spec-ai-quality-gate.yaml` を generation draft 用に分離しているため、implementation progress semantics と spec artifact semantics は混ざらない。
 
-read-only workflows は collect/validate/report の責務を持ち、`edit: false` を維持する。gate coverage は validator で禁止する側に倒し、AI fix loop の混入を drift として扱う。
+`kiro-discovery` は `classify-action-path -> plan-discovery-artifacts -> write-discovery-artifacts -> report-discovery` の形を持つ。`write-discovery-artifacts` だけが edit-capable で、`brief.md` と `.kiro/steering/roadmap.md` を生成または更新する。discovery gate の最小挿入点は `write-discovery-artifacts` の成功 path と `report-discovery` の間である。`need_replan` は `plan-discovery-artifacts` に戻すため、caller workflow は `plan-discovery-artifacts -> write-discovery-artifacts -> ai-quality-gate-discovery` を含む loop monitor を持つ。
 
 ### Architecture Pattern & Boundary Map
 
-採用パターンは「coverage inventory + scoped callable gate + validator-backed contracts」である。implementation gate と generation gate は report semantics と fix instruction を分けるが、PR #90 の 6 点契約は shared validator helper で共通化する。
+採用パターンは「coverage inventory + scoped callable gates + validator-backed allowlist」である。implementation、spec generation、discovery はそれぞれ report names と fix instruction を分けるが、PR #90 の 6 点契約は shared helper で共通化する。
 
 ```mermaid
 graph TB
     Inventory[Coverage Inventory] --> SharedContracts[Shared Gate Contracts]
     SharedContracts --> ImplGate[Implementation Gate]
     SharedContracts --> SpecGate[Spec Generation Gate]
-    SpecGate --> RequirementsFlow[Requirements Flow]
-    SpecGate --> DesignFlow[Design Flow]
-    SpecGate --> TasksFlow[Tasks Flow]
-    SpecGate --> QuickFlow[Quick Flow]
+    SharedContracts --> DiscoveryGate[Discovery Artifact Gate]
+    SpecGate --> SpecFlows[Spec Generation Flows]
+    DiscoveryGate --> DiscoveryFlow[Discovery Flow]
+    Inventory --> BatchDelegation[Batch Delegation]
     Inventory --> ReadOnlyGuard[Read Only Guard]
-    Inventory --> OrchestrationDecision[Orchestration Decision]
     SharedContracts --> Validators[Validators]
     Validators --> SmokeTests[Smoke Tests]
 ```
@@ -91,8 +98,8 @@ graph TB
 |---|---|---|---|
 | Workflow runtime | TAKT `^0.43.0` | `workflow_call`、rules、loop monitor の実行基盤 | 新規外部依存なし |
 | Validation | Node.js ESM scripts | YAML text/shape validation、coverage inventory validation | 既存 validator pattern を拡張 |
-| Tests | `node --test` | validator unit tests と runtime smoke | 既存 npm scripts に追加 |
-| Facets | TAKT Markdown facets | generation gate instruction/output contract、downstream evidence consumption | en/ja machine terms は一致させる |
+| Tests | `node --test` | validator unit tests と runtime smoke | 既存 npm scripts に追加または更新 |
+| Facets | TAKT Markdown facets | scoped gate instruction/output contract、downstream evidence consumption | en/ja machine terms は一致させる |
 
 ## File Structure Plan
 
@@ -102,6 +109,8 @@ graph TB
 .takt/
 ├── en/
 │   ├── workflows/
+│   │   ├── kiro-discovery-ai-quality-gate.yaml
+│   │   ├── kiro-discovery.yaml
 │   │   ├── kiro-spec-ai-quality-gate.yaml
 │   │   ├── kiro-spec-requirements.yaml
 │   │   ├── kiro-spec-design.yaml
@@ -109,12 +118,15 @@ graph TB
 │   │   └── kiro-spec-quick.yaml
 │   └── facets/
 │       ├── instructions/
+│       │   ├── kiro-ai-antipattern-fix-discovery.md
 │       │   ├── kiro-ai-antipattern-fix-spec-generation.md
+│       │   ├── kiro-discovery.md
 │       │   ├── kiro-spec-requirements-review.md
 │       │   ├── kiro-validate-design-readiness.md
 │       │   ├── kiro-spec-tasks-review.md
 │       │   └── kiro-spec-quick-sanity-review.md
 │       ├── output-contracts/
+│       │   ├── kiro-discovery-ai-antipattern-fix-result.md
 │       │   └── kiro-spec-ai-antipattern-fix-result.md
 │       └── policies/
 │           └── kiro-ai-quality-gate-coverage.md
@@ -125,32 +137,34 @@ scripts/
 ├── validate-kiro-ai-quality-gate-workflow-coverage.mjs
 ├── validate-kiro-shared-contracts.mjs
 ├── validate-kiro-spec-generation-workflows.mjs
+├── validate-kiro-discovery-batch-workflows.mjs
 └── validate-kiro-status-validation-workflows.mjs
 tests/
 ├── kiro-ai-quality-gate-workflow-coverage.test.mjs
-└── kiro-spec-ai-quality-gate-runtime-smoke.test.mjs
+├── kiro-discovery-batch-workflows.test.mjs
+├── kiro-spec-ai-quality-gate-runtime-smoke.test.mjs
+└── kiro-discovery-ai-quality-gate-runtime-smoke.test.mjs
 ```
 
 ### Modified Files
 
-- `.takt/{en,ja}/workflows/kiro-spec-ai-quality-gate.yaml` — 新規 generation-scoped callable gate。implementation gate と別 report names を持つ。
-- `.takt/{en,ja}/workflows/kiro-spec-requirements.yaml` — requirements draft generation/repair と review の間に spec AI gate call を追加し、loop monitor を実際の循環に合わせる。
-- `.takt/{en,ja}/workflows/kiro-spec-design.yaml` — design/research draft generation/repair と readiness review の間に spec AI gate call を追加する。
-- `.takt/{en,ja}/workflows/kiro-spec-tasks.yaml` — task plan draft generation/repair と task review の間に spec AI gate call を追加する。
-- `.takt/{en,ja}/workflows/kiro-spec-quick.yaml` — quick requirements/design/tasks phase に同じ spec AI gate call を追加する。phase workflow reuse は引き続き禁止する。
-- `.takt/{en,ja}/facets/instructions/kiro-ai-antipattern-fix-spec-generation.md` — spec artifact boundary 内で修正できる AI antipattern の修正指示。
-- `.takt/{en,ja}/facets/output-contracts/kiro-spec-ai-antipattern-fix-result.md` — generation fix report の machine fields と optional semantics。
-- `.takt/{en,ja}/facets/policies/kiro-ai-quality-gate-coverage.md` — coverage category と各 Kiro workflow の分類理由。
-- `.takt/{en,ja}/facets/instructions/kiro-spec-requirements-review.md`、`kiro-validate-design-readiness.md`、`kiro-spec-tasks-review.md`、`kiro-spec-quick-sanity-review.md` — unresolved gate findings と optional fix report の扱いを追加する。
-- `scripts/kiro-ai-quality-gate-contracts.mjs` — coverage inventory、allowed call sites、routing/report contract terms の shared helper。
-- `scripts/validate-kiro-ai-quality-gate-workflow-coverage.mjs` — Kiro workflow coverage の主 validator。
-- `scripts/validate-kiro-shared-contracts.mjs` — allowed `workflow_call` を helper 由来の allowlist に更新する。
-- `scripts/validate-kiro-spec-generation-workflows.mjs` — gate placement、quick の限定的 `workflow_call` 許可、downstream evidence terms を検証する。
-- `scripts/validate-kiro-status-validation-workflows.mjs` — read-only workflow への gate/fix loop 混入禁止を helper と同期する。
-- `tests/kiro-ai-quality-gate-workflow-coverage.test.mjs` — validator の positive/negative coverage。
-- `tests/kiro-spec-ai-quality-gate-runtime-smoke.test.mjs` — generation-scoped gate の決定論的 successful path smoke。
-- `package.json` — validator/test npm scripts を追加する。
-- `.github/workflows/ci.yml` — 既存 CI が Kiro validator/test scripts を個別列挙している場合のみ、新 scripts を追加する。
+- `.takt/{en,ja}/workflows/kiro-discovery-ai-quality-gate.yaml` — 新規 discovery-scoped callable gate。`kiro-discovery-ai-antipattern-review.md` と optional `kiro-discovery-ai-antipattern-fix.md` を出力する。
+- `.takt/{en,ja}/workflows/kiro-discovery.yaml` — `write-discovery-artifacts` 成功 path を `ai-quality-gate-discovery` に接続し、gate `COMPLETE` を `report-discovery`、`need_replan` を `plan-discovery-artifacts`、`ABORT` を `ABORT` に接続する。caller loop monitor は `plan-discovery-artifacts`、`write-discovery-artifacts`、`ai-quality-gate-discovery` を含む。
+- `.takt/{en,ja}/workflows/kiro-spec-ai-quality-gate.yaml` — 既存 generation-scoped callable gate。discovery と report names を共有しない。
+- `.takt/{en,ja}/workflows/kiro-spec-requirements.yaml`、`kiro-spec-design.yaml`、`kiro-spec-tasks.yaml`、`kiro-spec-quick.yaml` — 既存 generation gate integration を維持し、discovery gate 追加に合わせた shared contract allowlist と parity を満たす。
+- `.takt/{en,ja}/facets/instructions/kiro-ai-antipattern-fix-discovery.md` — `brief.md` と roadmap artifact 境界内で修正できる AI antipattern の修正指示。requirements/design/tasks/implementation files の直接修正を禁止する。
+- `.takt/{en,ja}/facets/output-contracts/kiro-discovery-ai-antipattern-fix-result.md` — discovery fix report の machine fields と optional semantics。
+- `.takt/{en,ja}/facets/instructions/kiro-discovery.md` — `report-discovery` が namespaced discovery gate evidence を確認する指示を追加する。
+- `.takt/{en,ja}/facets/policies/kiro-ai-quality-gate-coverage.md` — `discovery_artifact_gate_required` category と `kiro-discovery` の分類理由を説明する。
+- `scripts/kiro-ai-quality-gate-contracts.mjs` — coverage category、`kiro-discovery` entry、allowed discovery gate call site、discovery report names を追加する。
+- `scripts/validate-kiro-ai-quality-gate-workflow-coverage.mjs` — discovery gate required / forbidden implementation fix instruction / report evidence / parity checks を追加する。
+- `scripts/validate-kiro-shared-contracts.mjs` — allowed `workflow_call` を helper 由来の allowlist に同期し、discovery gate だけを追加許可する。
+- `scripts/validate-kiro-discovery-batch-workflows.mjs` — `kiro-discovery` の approved discovery gate call は許可し、phase reuse と `kiro-spec-batch` direct gate は禁止し続ける。
+- `scripts/validate-kiro-status-validation-workflows.mjs` — read-only workflow への discovery/spec/implementation gate 混入を forbidden terms に含める。
+- `tests/kiro-ai-quality-gate-workflow-coverage.test.mjs` — discovery category、call site、report names、negative cases を追加する。
+- `tests/kiro-discovery-batch-workflows.test.mjs` — discovery gate insertion と batch non-insertion を検証する。
+- `tests/kiro-discovery-ai-quality-gate-runtime-smoke.test.mjs` — deterministic successful path で discovery gate wiring を検証する。
+- `package.json`、`.github/workflows/ci.yml` — 既存 script 列挙方式の場合のみ、新 validator/test を追加する。
 
 ## System Flows
 
@@ -160,15 +174,35 @@ tests/
 flowchart TD
     Workflow[Kiro Workflow] --> WritesArtifacts{Writes Artifacts}
     WritesArtifacts -->|No| ReadOnly[Read Only Out Of Scope]
-    WritesArtifacts -->|Yes| GeneratesDraft{Generates Draft}
-    GeneratesDraft -->|Yes| Eligible[Generation Scoped Gate Required]
-    GeneratesDraft -->|No| Orchestrates{Orchestrates Workers}
-    Orchestrates -->|Yes| Delegated[Orchestration Delegated]
-    Orchestrates -->|No| NotApplicable[Intentionally Not Applicable]
-    Eligible --> Gate[Spec AI Quality Gate]
+    WritesArtifacts -->|Yes| GenerationDraft{Generates Spec Draft}
+    GenerationDraft -->|Yes| GenerationGate[Generation Scoped Gate Required]
+    GenerationDraft -->|No| DiscoveryArtifacts{Writes Discovery Artifacts}
+    DiscoveryArtifacts -->|Yes| DiscoveryGate[Discovery Artifact Gate Required]
+    DiscoveryArtifacts -->|No| Orchestration{Orchestrates Workers}
+    Orchestration -->|Yes| Delegated[Orchestration Delegated]
+    Orchestration -->|No| NotApplicable[Intentionally Not Applicable]
 ```
 
-`kiro-impl` は existing gate coverage、`kiro-spec-requirements/design/tasks/quick` は generation-scoped gate required、`kiro-spec-init` は intentionally not applicable、`kiro-discovery` と `kiro-spec-batch` は orchestration delegated、`kiro-spec-status` と `kiro-validate-*` は read-only out of scope と分類する。新規または未判断の orchestration workflow は orchestration decision required とし、maintainer が delegated / covered / out of scope のいずれかへ明示的に決めるまで covered と扱わない。
+`kiro-ai-quality-gate`、`kiro-spec-ai-quality-gate`、`kiro-discovery-ai-quality-gate` は existing gate coverage、`kiro-impl` は existing gate coverage caller、`kiro-spec-requirements/design/tasks/quick` は generation-scoped gate required、`kiro-discovery` は discovery artifact gate required、`kiro-spec-batch` は orchestration delegated、`kiro-spec-init` は intentionally not applicable、`kiro-spec-status` と `kiro-validate-*` は read-only out of scope と分類する。
+
+### Discovery Gate Sequence
+
+```mermaid
+sequenceDiagram
+    participant Classify
+    participant Plan
+    participant Write
+    participant DiscoveryGate
+    participant Report
+    Classify->>Plan: New spec action path
+    Plan->>Write: Planned brief and roadmap
+    Write->>DiscoveryGate: Created discovery artifacts
+    DiscoveryGate->>Report: No blocking AI finding
+    DiscoveryGate->>Plan: Need replan with monitored cycle
+    DiscoveryGate->>Report: Blocked finding
+```
+
+discovery gate は `write-discovery-artifacts` の成功後にだけ実行する。`EXISTING_SPEC_UPDATE` や `DIRECT_IMPLEMENTATION` のように discovery artifact を書かない path は gate を通さず `report-discovery` へ進む。
 
 ### Generation Gate Sequence
 
@@ -193,58 +227,68 @@ gate は draft を review し、fixable issue は既存 repair path に返す。
 
 | Requirement | Summary | Components | Interfaces | Flows |
 |---|---|---|---|---|
-| 1.1 | 全 Kiro workflow を一意に分類 | CoverageInventoryContract, CoverageValidator | coverage categories | Coverage Classification |
-| 1.2 | 必要な category を定義 | CoverageInventoryContract | `CoverageCategory` | Coverage Classification |
-| 1.3 | out-of-scope 理由を記録 | CoverageInventoryContract | helper reason field and policy explanation | Coverage Classification |
+| 1.1 | 全 Kiro workflow を一意に分類 | CoverageInventoryContract, CoverageValidator | coverage entries | Coverage Classification |
+| 1.2 | category set を定義 | CoverageInventoryContract | `CoverageCategory` | Coverage Classification |
+| 1.3 | out-of-scope 理由を記録 | CoverageInventoryContract | reason field | Coverage Classification |
 | 1.4 | 未分類を maintainer decision にする | CoverageValidator | classification failure | Coverage Classification |
 | 2.1 | artifact generation/repair を eligible にする | CoverageInventoryContract, GenerationWorkflowIntegration | eligibility rules | Coverage Classification |
-| 2.2 | read-only workflow を out of scope に保つ | ReadOnlyGuardValidator | forbidden gate/fix checks | Coverage Classification |
-| 2.3 | orchestration は明示判断 | CoverageInventoryContract | delegated owner field | Coverage Classification |
-| 2.4 | read-only から edit 化する plan を拒否 | ReadOnlyGuardValidator | edit capability checks | Coverage Classification |
+| 2.2 | read-only workflow を fix loop 外に保つ | ReadOnlyGuardValidator | forbidden gate checks | Coverage Classification |
+| 2.3 | orchestration は明示判断 | CoverageInventoryContract | decision category | Coverage Classification |
+| 2.4 | read-only edit 化を拒否 | ReadOnlyGuardValidator | edit capability checks | Coverage Classification |
 | 2.5 | 機械的な全挿入を防止 | CoverageValidator | exact allowlist | Coverage Classification |
-| 3.1 | relative workflow path を要求 | SharedGateContractHelper | allowed call site | Generation Gate Sequence |
-| 3.2 | built-in vocabulary 互換 | SharedGateContractHelper, SpecAiQualityGateWorkflow | routing terms | Generation Gate Sequence |
-| 3.3 | ambiguous/blocked/inconsistent を catch | SpecAiQualityGateWorkflow | catch-all routing | Generation Gate Sequence |
-| 3.4 | fix report optional | SpecAiQualityGateWorkflow, GateEvidenceAdapters | optional report semantics | Generation Gate Sequence |
-| 3.5 | loop exhaustion を repair/replan へ返す | SpecAiQualityGateWorkflow | loop monitor outcomes | Generation Gate Sequence |
-| 3.6 | caller loop monitor に gate step を含める | GenerationWorkflowIntegration | loop monitor cycle | Generation Gate Sequence |
+| 2.6 | discovery artifacts を eligible にする | DiscoveryWorkflowIntegration | discovery category | Discovery Gate Sequence |
+| 2.7 | discovery と implementation fix を分離 | DiscoveryAiQualityGateWorkflow | discovery fix instruction | Discovery Gate Sequence |
+| 3.1 | relative workflow path を要求 | SharedGateContractHelper | allowed call site | Discovery Gate Sequence, Generation Gate Sequence |
+| 3.2 | built-in vocabulary 互換 | SharedGateContractHelper | routing terms | Discovery Gate Sequence, Generation Gate Sequence |
+| 3.3 | ambiguous/blocked/inconsistent を catch | SpecAiQualityGateWorkflow, DiscoveryAiQualityGateWorkflow | catch-all routing | Discovery Gate Sequence, Generation Gate Sequence |
+| 3.4 | fix report optional | SpecAiQualityGateWorkflow, DiscoveryAiQualityGateWorkflow, GateEvidenceAdapters | optional report semantics | Discovery Gate Sequence, Generation Gate Sequence |
+| 3.5 | loop exhaustion を repair/replan へ返す | SpecAiQualityGateWorkflow, DiscoveryAiQualityGateWorkflow | loop monitor outcomes | Discovery Gate Sequence, Generation Gate Sequence |
+| 3.6 | caller loop monitor に gate step を含める | GenerationWorkflowIntegration, DiscoveryWorkflowIntegration | monitored caller cycle | Discovery Gate Sequence, Generation Gate Sequence |
+| 3.7 | discovery outcomes に同じ契約を適用 | DiscoveryAiQualityGateWorkflow | discovery routing | Discovery Gate Sequence |
 | 4.1 | requirements draft を gate する | GenerationWorkflowIntegration | requirements gate call | Generation Gate Sequence |
 | 4.2 | design/research draft を gate する | GenerationWorkflowIntegration | design gate call | Generation Gate Sequence |
 | 4.3 | task plan draft を gate する | GenerationWorkflowIntegration | tasks gate call | Generation Gate Sequence |
 | 4.4 | boundary 内修正は repair path | SpecAiQualityGateWorkflow | repair routing | Generation Gate Sequence |
 | 4.5 | upstream/boundary 拡張は replan | SpecAiQualityGateWorkflow | upstream repair routing | Generation Gate Sequence |
-| 5.1 | downstream review が unresolved findings を見る | GateEvidenceAdapters | review facet terms | Generation Gate Sequence |
-| 5.2 | stale/cross-run/evidence-free fix を拒否 | GateEvidenceAdapters | fix report validation | Generation Gate Sequence |
-| 5.3 | missing optional fix report を許容 | GateEvidenceAdapters | optional report semantics | Generation Gate Sequence |
-| 5.4 | rejected evidence を repair/replan/blocked へ返す | GateEvidenceAdapters | downstream routing | Generation Gate Sequence |
-| 5.5 | promotion は verified review/finalize に依存 | GenerationWorkflowIntegration | finalize dependency | Generation Gate Sequence |
+| 5.1 | downstream review が unresolved findings を見る | GateEvidenceAdapters | review facet terms | Discovery Gate Sequence, Generation Gate Sequence |
+| 5.2 | stale/cross-run/evidence-free fix を拒否 | GateEvidenceAdapters | fix report validation | Discovery Gate Sequence, Generation Gate Sequence |
+| 5.3 | missing optional fix report を許容 | GateEvidenceAdapters | optional report semantics | Discovery Gate Sequence, Generation Gate Sequence |
+| 5.4 | rejected evidence を repair/replan/blocked へ返す | GateEvidenceAdapters | downstream routing | Discovery Gate Sequence, Generation Gate Sequence |
+| 5.5 | promotion は verified result に依存 | GenerationWorkflowIntegration | finalize dependency | Generation Gate Sequence |
+| 5.6 | discovery report が gate evidence を見る | DiscoveryWorkflowIntegration, GateEvidenceAdapters | report-discovery evidence check | Discovery Gate Sequence |
 | 6.1 | status/validate は edit gate なし | ReadOnlyGuardValidator | forbidden edit behavior | Coverage Classification |
-| 6.2 | discovery の委譲先を分類 | CoverageInventoryContract | delegated owner field | Coverage Classification |
-| 6.3 | batch の委譲先を分類 | CoverageInventoryContract | delegated owner field | Coverage Classification |
-| 6.4 | orchestration out-of-scope に adjacent owner を記録 | CoverageInventoryContract | adjacent workflow field | Coverage Classification |
-| 6.5 | roadmap marker を progress 判断に使わない | CoverageInventoryContract | classification evidence rule | Coverage Classification |
+| 6.2 | discovery 完了前に AI quality 評価 | DiscoveryWorkflowIntegration | discovery gate call | Discovery Gate Sequence |
+| 6.3 | discovery 境界内修正は repair | DiscoveryAiQualityGateWorkflow | discovery repair routing | Discovery Gate Sequence |
+| 6.4 | decomposition/ownership/human clarification は replan | DiscoveryAiQualityGateWorkflow | need_replan routing | Discovery Gate Sequence |
+| 6.5 | batch の委譲先を分類 | CoverageInventoryContract | adjacent owner field | Coverage Classification |
+| 6.6 | orchestration out-of-scope に owner を記録 | CoverageInventoryContract | adjacent owner field | Coverage Classification |
+| 6.7 | roadmap marker を progress 判断に使わない | CoverageInventoryContract | evidence rule | Coverage Classification |
 | 7.1 | eligible bypass を検出 | CoverageValidator | required gate checks | Coverage Classification |
 | 7.2 | read-only fix loop 追加を検出 | ReadOnlyGuardValidator | forbidden loop checks | Coverage Classification |
-| 7.3 | PR #90 contract drift を検出 | SharedGateContractHelper | six contract checks | Generation Gate Sequence |
-| 7.4 | deterministic successful path smoke | RuntimeSmokeFixture | smoke command | Generation Gate Sequence |
+| 7.3 | PR #90 contract drift を検出 | SharedGateContractHelper | six contract checks | Discovery Gate Sequence, Generation Gate Sequence |
+| 7.4 | deterministic successful path smoke | RuntimeSmokeFixture | smoke command | Discovery Gate Sequence, Generation Gate Sequence |
 | 7.5 | 判定不能を actionable failure にする | CoverageValidator | failure message contract | Coverage Classification |
+| 7.6 | missing discovery gate を検出 | CoverageValidator | discovery required gate check | Discovery Gate Sequence |
+| 7.7 | implementation fix instruction の誤配線を検出 | CoverageValidator | discovery fix instruction guard | Discovery Gate Sequence |
 | 8.1 | en/ja workflow structure parity | CoverageValidator | parity checks | Coverage Classification |
 | 8.2 | facet machine fields parity | CoverageValidator | report/routing term checks | Coverage Classification |
 | 8.3 | upstream skill asset を変更しない | CoverageInventoryContract | out-of-boundary guard | Coverage Classification |
-| 8.4 | TAKT runtime prompt priority で補正 | GateEvidenceAdapters | facet policy/instruction | Generation Gate Sequence |
+| 8.4 | TAKT runtime prompt priority で補正 | GateEvidenceAdapters | facet policy/instruction | Discovery Gate Sequence, Generation Gate Sequence |
 | 8.5 | language drift を covered 前に報告 | CoverageValidator | parity failure | Coverage Classification |
 
 ## Components and Interfaces
 
 | Component | Domain / Layer | Intent | Req Coverage | Key Dependencies | Contracts |
 |---|---|---|---|---|---|
-| CoverageInventoryContract | Policy / Config | Kiro workflow coverage の分類正本 | 1.1-1.4, 2.1-2.5, 6.2-6.5, 8.3 | workflows P0, TAKT.md policy P1 | State |
+| CoverageInventoryContract | Policy / Config | Kiro workflow coverage の分類正本 | 1.1-1.4, 2.1-2.6, 6.5-6.7, 8.3 | workflows P0 | State |
 | SharedGateContractHelper | Validation / Shared | PR #90 の 6 点契約を validator 間で共有 | 3.1-3.6, 7.3 | existing validators P0 | Service |
-| SpecAiQualityGateWorkflow | Workflow Runtime | generation draft 用 AI antipattern review/fix gate | 3.2-3.5, 4.1-4.5 | built-in reviewer P0, generation fix facet P0 | Batch |
-| GenerationWorkflowIntegration | Workflow Runtime | eligible generation workflows への gate insertion | 2.1, 3.6, 4.1-4.5, 5.5, 8.1 | spec generation workflows P0 | Batch |
-| GateEvidenceAdapters | Facets | downstream review/finalize が gate evidence を消費 | 5.1-5.5, 8.2, 8.4 | review facets P0 | State |
-| CoverageValidator | Validation | coverage/parity/allowlist drift を検出 | 1.1-1.4, 7.1, 7.3, 7.5, 8.1-8.5 | helper P0, filesystem P0 | Service |
-| ReadOnlyGuardValidator | Validation | read-only workflow への gate/fix 混入を拒否 | 2.2, 2.4, 6.1, 7.2 | status validation validator P0 | Service |
+| SpecAiQualityGateWorkflow | Workflow Runtime | generation draft 用 AI review/fix gate | 3.2-3.5, 4.1-4.5 | built-in reviewer P0 | Batch |
+| DiscoveryAiQualityGateWorkflow | Workflow Runtime | discovery artifact 用 AI review/fix gate | 2.7, 3.2-3.7, 6.2-6.4, 7.7 | built-in reviewer P0 | Batch |
+| GenerationWorkflowIntegration | Workflow Runtime | eligible generation workflows への gate insertion | 2.1, 3.6, 4.1-4.5, 5.5, 8.1 | spec workflows P0 | Batch |
+| DiscoveryWorkflowIntegration | Workflow Runtime | discovery artifact write path への gate insertion | 2.6, 3.6, 5.6, 6.2-6.4, 8.1 | kiro-discovery P0 | Batch |
+| GateEvidenceAdapters | Facets | downstream review/finalize/report が gate evidence を消費 | 5.1-5.6, 8.2, 8.4 | review/report facets P0 | State |
+| CoverageValidator | Validation | coverage/parity/allowlist drift を検出 | 1.1-1.4, 7.1, 7.3, 7.5-7.7, 8.1-8.5 | helper P0, filesystem P0 | Service |
+| ReadOnlyGuardValidator | Validation | read-only workflow への gate/fix 混入を拒否 | 2.2, 2.4, 6.1, 7.2 | status validator P0 | Service |
 | RuntimeSmokeFixture | Tests | deterministic successful gate path を実行 | 7.4 | npm scripts P0, TAKT runtime P0 | Batch |
 
 ### Policy and Validation
@@ -253,137 +297,100 @@ gate は draft を review し、fixable issue は既存 repair path に返す。
 
 | Field | Detail |
 |---|---|
-| Intent | 各 Kiro workflow の coverage category、理由、adjacent owner を定義する |
-| Requirements | 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 2.5, 6.2, 6.3, 6.4, 6.5, 8.3 |
+| Intent | 各 Kiro workflow の coverage category、理由、allowed gate call、adjacent owner を定義する |
+| Requirements | 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 6.5, 6.6, 6.7, 8.3 |
 
 **Responsibilities & Constraints**
+- `scripts/kiro-ai-quality-gate-contracts.mjs` を machine-readable 正本にする。
+- `discovery_artifact_gate_required` を category set に追加する。
+- `kiro-discovery-ai-quality-gate` は callable gate 自体として `existing_gate_coverage` に分類し、全 workflow exactly once invariant を満たす。
+- `kiro-discovery` は `allowedGateCall: "./kiro-discovery-ai-quality-gate.yaml"` を持つ。
+- `kiro-spec-batch` は `orchestration_delegated` のまま adjacent owner を worker generation workflows にする。
 
-- `scripts/kiro-ai-quality-gate-contracts.mjs` に workflow ごとの machine-readable classification、reason、adjacent owner を置き、validator の正本にする。
-- `.takt/{en,ja}/facets/policies/kiro-ai-quality-gate-coverage.md` は category semantics、判断基準、operator 向け説明を置く。workflow ごとの分類表は再掲しない。
-- roadmap checkbox marker は spec 生成済み marker として扱い、implementation progress 判断には使わない。
-- `kiro-discovery` は discovery output を直接 gate せず、`kiro-spec-init` 以降の spec generation を adjacent owner とする。
-- `kiro-spec-batch` は worker generation workflows を artifact-level gate owner とする。
-
-**Service Interface**
-
-```typescript
-type CoverageCategory =
-  | "existing_gate_coverage"
-  | "generation_scoped_gate_required"
-  | "orchestration_decision_required"
-  | "orchestration_delegated"
-  | "read_only_out_of_scope"
-  | "intentionally_not_applicable"
-  | "maintainer_decision_required";
-
-interface KiroWorkflowCoverageEntry {
-  workflowName: string;
-  category: CoverageCategory;
-  reason: string;
-  adjacentOwner?: string;
-  allowedGateCall?: string;
-}
-```
-
-**Implementation Notes**
-
-- Integration: helper を分類の正本にし、policy facet は helper の category semantics を説明する補助文書に留める。
-- Validation: 全 workflow が正確に 1 category を持つことを検証する。
-- Risks: policy facet が workflow 別分類を再掲し始めると drift source になるため、validator/test は policy facet に category semantics と正本参照があることだけを検証する。
+**Contracts**: State
+- State model: immutable coverage entry list。
+- Invariants: every Kiro workflow appears exactly once; allowed call path is relative; category reason is non-empty。
 
 #### SharedGateContractHelper
 
 | Field | Detail |
 |---|---|
-| Intent | implementation gate と generation gate に共通する contract terms と call allowlist を提供する |
+| Intent | implementation/spec/discovery gate の allowed call sites と shared routing terms を提供する |
 | Requirements | 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 7.3 |
 
 **Responsibilities & Constraints**
+- allowed call site は workflow name、step name、call path、gate kind を持つ。
+- gate kind は `implementation`、`spec_generation`、`discovery_artifact` を区別する。
+- shared terms は built-in reviewer vocabulary と PR #90 catch-all semantics に揃える。
 
-- allowed `workflow_call` は workflow name、step name、relative call path で定義する。
-- bare workflow name call、未分類 caller、read-only caller を拒否する。
-- routing vocabulary、optional fix report、catch-all routing、loop exhaustion outcome、caller loop monitor membership の検証語彙を提供する。
-
-**Service Interface**
-
+**Contracts**: Service
 ```typescript
-interface AllowedWorkflowCallSite {
+type GateKind = "implementation" | "spec_generation" | "discovery_artifact";
+
+interface AllowedGateCallSite {
   workflowName: string;
   stepName: string;
-  callPath: string;
-  gateKind: "implementation" | "spec_generation";
-}
-
-interface GateContractTerms {
-  reviewReports: readonly string[];
-  optionalFixReports: readonly string[];
-  routingTerms: readonly string[];
-  catchAllTerms: readonly string[];
-  loopOutcomeTerms: readonly string[];
+  callPath: `./${string}.yaml`;
+  gateKind: GateKind;
 }
 ```
 
-**Implementation Notes**
-
-- Integration: `validate-kiro-shared-contracts.mjs` と新 coverage validator が同じ helper を import する。
-- Validation: `kiro-impl` の既存 call site を壊さず、spec generation caller を相対 path のみ許可する。
-- Risks: helper が肥大化しないよう、YAML parser ではなく既存 validator style に沿った bounded text/shape checks に留める。
-
 ### Workflow Runtime
 
-#### SpecAiQualityGateWorkflow
+#### DiscoveryAiQualityGateWorkflow
 
 | Field | Detail |
 |---|---|
-| Intent | requirements/design/tasks draft に対する AI antipattern review/fix を domain review 前に実行する |
-| Requirements | 3.2, 3.3, 3.4, 3.5, 4.1, 4.2, 4.3, 4.4, 4.5 |
+| Intent | discovery-owned `brief.md` / roadmap artifact を AI antipattern review/fix gate に通す |
+| Requirements | 2.7, 3.2, 3.3, 3.4, 3.5, 3.7, 6.2, 6.3, 6.4, 7.7 |
 
 **Responsibilities & Constraints**
+- `ai-antipattern-reviewer` を最初に実行し、blocking issue がなければ fix report なしで `COMPLETE` を返す。
+- fix step は `kiro-ai-antipattern-fix-discovery` だけを使う。
+- `brief.md` と `.kiro/steering/roadmap.md` 以外へ越境する修正は `need_replan` または blocked report にする。
+- report names は `kiro-discovery-ai-antipattern-review.md` と `kiro-discovery-ai-antipattern-fix.md` にする。
 
-- `.takt/{en,ja}/workflows/kiro-spec-ai-quality-gate.yaml` は `workflow_call` 専用の subworkflow とする。
-- built-in `ai-antipattern-reviewer` を first-pass review に使う。
-- report names は implementation gate と分離し、`kiro-spec-ai-antipattern-review.md` と optional `kiro-spec-ai-antipattern-fix.md` を使う。
-- fix instruction は current spec artifact boundary 内だけを修正対象にし、upstream phase 変更や roadmap 再分解を silent edit しない。
-- ambiguous、blocked、inconsistent outcome は repair/replan/maintainer-decision へ routing する。
+**Contracts**: Batch
+- Trigger: `kiro-discovery` の `ai-quality-gate-discovery` step。
+- Input / validation: discovery-created artifacts and context。
+- Output / destination: namespaced subworkflow reports。
+- Idempotency & recovery: no blocking issue path does not require fix report; loop exhaustion returns `need_replan` where caller can replan。
 
-**Batch / Job Contract**
-
-- Trigger: caller workflow の draft generation または repair step の直後。
-- Input: draft artifact content、feature name、phase、requirements/design/tasks context、generation-specific fix instruction。
-- Output: AI review report、optional fix report、next route。
-- Idempotency & recovery: no blocking finding の場合は fix report なしで完了できる。loop exhaustion 時は ABORT ではなく repair/replan outcome を返す。
-
-#### GenerationWorkflowIntegration
+#### DiscoveryWorkflowIntegration
 
 | Field | Detail |
 |---|---|
-| Intent | eligible generation workflow に spec AI gate を最小限の位置で挿入する |
-| Requirements | 2.1, 3.6, 4.1, 4.2, 4.3, 4.4, 4.5, 5.5, 8.1 |
+| Intent | artifact-writing discovery path だけを discovery gate へ接続する |
+| Requirements | 2.6, 3.6, 5.6, 6.2, 6.3, 6.4, 8.1 |
 
 **Responsibilities & Constraints**
+- `write-discovery-artifacts` success rules は `report-discovery` ではなく `ai-quality-gate-discovery` に進む。
+- `ai-quality-gate-discovery` は `kind: workflow_call` と `call: ./kiro-discovery-ai-quality-gate.yaml` を使う。
+- `COMPLETE` は `report-discovery`、`need_replan` は `plan-discovery-artifacts`、`ABORT` は `ABORT` に接続する。
+- caller loop monitor は `plan-discovery-artifacts`、`write-discovery-artifacts`、`ai-quality-gate-discovery` を cycle に含め、threshold 到達時は `report-discovery` の blocked path へ進む。
+- artifact を書かない action path は gate を通さない。
 
-- `kiro-spec-requirements/design/tasks` は generate/repair の後、domain review の前に gate call を置く。
-- `kiro-spec-quick` は quick requirements/design/tasks の各 phase で同じ gate call を使う。standalone phase workflow call は許可しない。
-- caller loop monitor は実際の循環に gate step を含める。
-- finalize step は gate report を直接再評価せず、domain review/finalize の verified result に依存する。
+**Contracts**: Batch
+- Trigger: `SINGLE_SPEC`、`MULTI_SPEC`、`MIXED_DECOMPOSITION` の successful write path。
+- Output / destination: final `kiro-discovery-result.md` reports gate evidence status。
+- Recovery: replan path returns to `plan-discovery-artifacts`; loop monitor threshold turns repeated non-convergence into blocked discovery reporting before abort。
 
-**Canonical step placement**
+#### SpecAiQualityGateWorkflow and GenerationWorkflowIntegration
 
-| Workflow | Gate step names | Required route shape | Loop monitor requirement |
-|---|---|---|---|
-| `kiro-spec-requirements` | `ai-quality-gate-requirements` | `generate-requirements -> ai-quality-gate-requirements -> review-requirements`; `repair-requirements -> ai-quality-gate-requirements` | cycle includes `ai-quality-gate-requirements`, `review-requirements`, `repair-requirements`, and finalize repair return if present |
-| `kiro-spec-design` | `ai-quality-gate-design` | `generate-design -> ai-quality-gate-design -> review-design`; `repair-design -> ai-quality-gate-design` | cycle includes `ai-quality-gate-design`, `review-design`, `repair-design`, and finalize repair return if present |
-| `kiro-spec-tasks` | `ai-quality-gate-tasks` | `generate-tasks -> ai-quality-gate-tasks -> review-tasks`; `repair-tasks -> ai-quality-gate-tasks` | cycle includes `ai-quality-gate-tasks`, `review-tasks`, `repair-tasks`, and finalize repair return if present |
-| `kiro-spec-quick` | `quick-ai-quality-gate-requirements`, `quick-ai-quality-gate-design`, `quick-ai-quality-gate-tasks` | each quick generate/repair step routes to its matching gate, then to the existing quick review step | each phase loop monitor includes its matching quick gate step plus existing review/repair/finalize cycle |
+| Field | Detail |
+|---|---|
+| Intent | spec generation draft を domain review / finalize 前に AI quality gate へ通す |
+| Requirements | 2.1, 3.2, 3.3, 3.4, 3.5, 3.6, 4.1, 4.2, 4.3, 4.4, 4.5, 5.5 |
 
-Every gate step uses `kind: workflow_call` and `call: ./kiro-spec-ai-quality-gate.yaml`. No quick gate step may call `./kiro-spec-requirements.yaml`, `./kiro-spec-design.yaml`, or `./kiro-spec-tasks.yaml`.
+**Responsibilities & Constraints**
+- 既存 `kiro-spec-ai-quality-gate.yaml` の separate report names と generation-specific fix instruction を維持する。
+- quick path は phase workflow reuse をしないが、single approved AI gate call は許可する。
+- domain review/finalize は unresolved/stale/cross-run/evidence-free gate evidence を拒否する。
 
-**Batch / Job Contract**
-
-- Trigger: spec generation workflow execution。
-- Input: workflow-specific draft result。
-- Output: existing generation result contract に compatible な route。
-- Idempotency & recovery: existing repair/finalize loop を維持し、gate は新しい artifact promotion owner にならない。
+**Contracts**: Batch
+- Trigger: generate/repair draft success。
+- Output / destination: namespaced spec AI reports。
+- Recovery: fixable issue は current generation artifact repair、boundary expansion は replan/upstream-repair outcome。
 
 ### Facets
 
@@ -391,117 +398,99 @@ Every gate step uses `kind: workflow_call` and `call: ./kiro-spec-ai-quality-gat
 
 | Field | Detail |
 |---|---|
-| Intent | downstream generation review/finalize が AI gate evidence を無視しないようにする |
-| Requirements | 5.1, 5.2, 5.3, 5.4, 5.5, 8.2, 8.4 |
+| Intent | review/finalize/report facets が scoped gate reports を解釈する |
+| Requirements | 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 8.2, 8.4 |
 
 **Responsibilities & Constraints**
+- spec generation review facets は `kiro-spec-ai-antipattern-review.md` と optional fix report を検査する。
+- `kiro-discovery.md` は namespaced `kiro-discovery-ai-antipattern-review.md` と optional fix report を検査する。
+- missing optional fix report は first review clean の場合だけ許容する。
+- stale/cross-run/evidence-free no-fix は rejection とし、既存 repair/replan/blocked path に戻す。
 
-- review facets は unresolved `kiro-spec-ai-antipattern-review.md` findings を rejection/repair signal として扱う。
-- optional `kiro-spec-ai-antipattern-fix.md` が存在する場合、stale、cross-run、blocked、evidence-free no-fix を拒否する。
-- first-pass no blocking で fix report が存在しない場合は failure にしない。
-- en/ja で report names、routing terms、machine fields を一致させる。
-
-**State Management**
-
-- State model: gate reports は runtime evidence であり、spec lifecycle metadata の正本ではない。
-- Persistence & consistency: lifecycle promotion は review/finalize の output contract によってのみ進む。
-- Concurrency strategy: 同一 workflow run の evidence と draft content の対応を review facet が確認する。
+**Contracts**: State
+- State model: gate evidence is scoped by subworkflow report path and report name。
+- Invariants: implementation report names are not accepted as discovery/spec evidence。
 
 ### Validation and Tests
 
-#### CoverageValidator
+#### CoverageValidator and ReadOnlyGuardValidator
 
 | Field | Detail |
 |---|---|
-| Intent | required gate coverage、allowed calls、language parity、classification drift を検出する |
-| Requirements | 1.1, 1.2, 1.3, 1.4, 7.1, 7.3, 7.5, 8.1, 8.2, 8.3, 8.4, 8.5 |
+| Intent | coverage drift、forbidden gate insertion、language parity drift を検出する |
+| Requirements | 1.1-1.4, 2.2, 2.4, 2.5, 7.1, 7.2, 7.3, 7.5, 7.6, 7.7, 8.1, 8.2, 8.5 |
 
 **Responsibilities & Constraints**
+- helper の allowed call sites 以外の Kiro `workflow_call` は failure にする。
+- `kiro-discovery` には discovery gate call が必須で、implementation/spec generation fix instruction は forbidden とする。
+- `kiro-spec-batch` と read-only workflows には direct gate/fix loop がないことを検証する。
+- en/ja の workflow call structure、report names、routing terms を比較する。
 
-- 全 Kiro workflow を `.takt/en` と `.takt/ja` の両方から列挙し、coverage entry の過不足を fail する。
-- eligible generation workflow が required gate call を持たない場合は fail する。
-- quick の `workflow_call` は `./kiro-spec-ai-quality-gate.yaml` のみ許可し、phase reuse call は引き続き fail する。
-- en/ja の step names、call paths、report names、machine routing terms の drift を fail する。
-
-**Service Interface**
-
+**Contracts**: Service
 ```typescript
-interface ValidationFinding {
-  filePath: string;
-  code: string;
-  message: string;
-}
-
 interface ValidationResult {
   ok: boolean;
-  findings: readonly ValidationFinding[];
+  failures: readonly string[];
 }
 ```
-
-#### ReadOnlyGuardValidator
-
-| Field | Detail |
-|---|---|
-| Intent | read-only workflow に AI fix loop や edit-capable behavior が入る回帰を防ぐ |
-| Requirements | 2.2, 2.4, 6.1, 7.2 |
-
-**Responsibilities & Constraints**
-
-- `kiro-spec-status` と `kiro-validate-*` に `workflow_call`、gate step、repair/debug/fix step、loop monitor、`edit: true` が追加されたら fail する。
-- existing `validate-kiro-status-validation-workflows.mjs` の責務を維持し、coverage helper で対象 workflow list を共有する。
 
 #### RuntimeSmokeFixture
 
 | Field | Detail |
 |---|---|
-| Intent | generation-scoped gate の successful path が TAKT runtime で決定論的に wire されることを確認する |
+| Intent | mock provider で gate wiring の successful path を決定論的に確認する |
 | Requirements | 7.4 |
 
-**Batch / Job Contract**
+**Responsibilities & Constraints**
+- existing spec generation smoke を維持する。
+- discovery smoke は artifact write success から discovery gate clean path を通って `report-discovery` に到達することだけを確認する。
+- provider は opt-in mock path を使い、通常実行が Codex provider に切り替わらないようにする。
 
-- Trigger: `npm run test:kiro-spec-ai-quality-gate-runtime-smoke`。
-- Input: fixture feature name と deterministic prompt/fixture context。
-- Output: `npm run kiro:spec:requirements -- "fixture"` 相当の successful gate path evidence。
-- Recovery: runtime smoke は artifact 品質評価ではなく wiring 検証だけを目的とし、mock/fake 可能な最小経路に限定する。
+**Contracts**: Batch
+- Trigger: npm test script。
+- Output / destination: TAP result。
+- Recovery: fixture failure is CI failure; no repository artifacts are mutated。
 
 ## Data Models
 
 ### Domain Model
 
-- `KiroWorkflowCoverageEntry` は workflow coverage の単位である。
-- `AllowedWorkflowCallSite` は `workflow_call` の許可単位である。
-- `GateContractTerms` は PR #90 の six-contract validator vocabulary の単位である。
-- `SpecGateEvidence` は review report と optional fix report の runtime evidence であり、spec lifecycle metadata ではない。
+- `CoverageEntry`: workflow name、category、reason、optional `allowedGateCall`、optional `adjacentOwner`。
+- `AllowedGateCallSite`: workflow name、step name、relative call path、gate kind。
+- `DiscoveryGateCycle`: caller cycle containing `plan-discovery-artifacts`、`write-discovery-artifacts`、`ai-quality-gate-discovery` and a threshold outcome。
+- `GateContractTerms`: gate kind ごとの review report names、optional fix report names、shared routing terms。
 
 ### Logical Data Model
 
-| Entity | Natural Key | Required Attributes | Integrity Rules |
-|---|---|---|---|
-| CoverageEntry | `workflowName` | `category`, `reason` | 全 Kiro workflow に exactly one entry |
-| AllowedCallSite | `workflowName + stepName` | `callPath`, `gateKind` | `callPath` は relative path のみ |
-| GateEvidence | `workflowRun + phase` | `reviewReport`, optional `fixReport` | optional fix report absence は first-pass pass のみ許容 |
+Coverage inventory は `scripts/kiro-ai-quality-gate-contracts.mjs` の immutable array を正本にする。policy facet は category semantics の説明だけを持ち、workflow-by-workflow table を複製しない。
 
 ## Error Handling
 
-- 未分類 workflow は `maintainer_decision_required` として明示 failure にする。
-- eligible workflow に gate call がない場合、どの workflow/phase にどの call を追加すべきかを validator message に含める。
-- read-only workflow に gate/fix behavior が入った場合、対象 step と read-only boundary violation を報告する。
-- downstream evidence が stale/cross-run/blocked の場合、review/finalize は既存 repair/replan/blocked route を返す。
+- 未分類 workflow は `MAINTAINER_DECISION_REQUIRED` として actionable failure にする。
+- read-only workflow への gate/fix loop 混入は validator failure にする。
+- `kiro-discovery` に implementation-scoped fix instruction が配線された場合は validator failure にする。
+- discovery gate の ambiguous/blocked/internally inconsistent outcome は catch-all replan path にする。
+- discovery replan cycle が loop monitor threshold に到達した場合は、追加修正を試みず blocked discovery result として報告する。
+- discovery artifact 境界を越える修正要求は silent edit せず `need_replan` または blocked report にする。
 
 ## Testing Strategy
 
-- `validate-kiro-ai-quality-gate-workflow-coverage.mjs` は、全 Kiro workflow の classification、eligible bypass、read-only illegal gate、unknown workflow を検出する。対象: 1.1-1.4, 2.1-2.5, 6.1-6.5, 7.1, 7.2, 7.5。
-- shared contract tests は relative call path、built-in routing vocabulary、catch-all routing、optional fix report、loop exhaustion outcome、caller loop monitor membership を検証する。対象: 3.1-3.6, 7.3。
-- spec generation validator tests は requirements/design/tasks/quick の gate placement と quick の限定的 `workflow_call` 許可を検証する。対象: 4.1-4.5, 8.1。
-- facet parity tests は en/ja の report names、machine fields、routing terms、upstream asset boundary terms を検証する。対象: 5.1-5.5, 8.2-8.5。
-- runtime smoke は generation-scoped gate の no blocking successful path を 1 本実行し、fix report がなくても pass できることを確認する。対象: 3.4, 7.4。
+- Coverage inventory tests: every Kiro workflow exactly once、category set、`kiro-discovery-ai-quality-gate` の `existing_gate_coverage`、`kiro-discovery` の `discovery_artifact_gate_required`、`kiro-spec-batch` の delegated owner。
+- Workflow call allowlist tests: implementation/spec/discovery approved calls only allowed、bare workflow name forbidden、relative path required。
+- Discovery workflow tests: successful write path routes to `ai-quality-gate-discovery`、artifact-less path bypasses gate、gate `COMPLETE` routes to `report-discovery`、`need_replan` routes to `plan-discovery-artifacts`、caller loop monitor includes `plan-discovery-artifacts` / `write-discovery-artifacts` / `ai-quality-gate-discovery`。
+- Discovery facet tests: `kiro-discovery.md` が namespaced discovery gate reports、optional fix report、stale/cross-run/evidence-free rejection、implementation report rejection を含む。
+- Read-only/batch negative tests: status/validate/batch workflows do not gain direct AI fix loop。
+- Language parity tests: en/ja workflow structure、report names、routing terms、facet machine terms。
+- Runtime smoke: spec generation clean path と discovery clean path を mock provider で決定論的に実行する。
 
-## Rollout and Migration
+## Security and Performance
 
-1. coverage helper を正本として追加し、policy facet には category semantics と正本参照だけを追加して、既存 workflow の分類を validator で固定する。
-2. generation-scoped gate workflow と facets を en/ja に追加する。
-3. requirements/design/tasks/quick caller に gate call と loop monitor 更新を入れる。
-4. downstream review/finalize facets に evidence consumption を追加する。
-5. validators/tests/smoke を追加し、CI に組み込む。
+新規外部依存は導入しない。discovery gate は edit-capable subworkflow だが、fix instruction と validator で writable boundary を `brief.md` / roadmap artifact に限定する。runtime cost は discovery artifact write path に 1 callable gate を追加する分だけ増えるため、artifact-less path は gate を bypass する。
 
-この順序により、分類と禁止境界を先に固定してから runtime wiring を広げる。
+## Migration and Rollout
+
+1. Coverage inventory と validators を discovery category 対応へ更新する。
+2. discovery gate workflow/facets を en/ja で追加する。
+3. `kiro-discovery` の successful artifact write path に gate call を挿入する。
+4. discovery-batch validator の `workflow_call` 一律禁止を allowlist ベースへ狭める。
+5. unit tests と runtime smoke を追加し、既存 generation gate tests を維持する。

--- a/.kiro/specs/kiro-ai-quality-gate-workflow-coverage/requirements.md
+++ b/.kiro/specs/kiro-ai-quality-gate-workflow-coverage/requirements.md
@@ -6,18 +6,20 @@
 
 この spec は、`cc-sdd-*`、`opsx-*`、OpenSpec-compatible workflow、upstream `.agents/skills/kiro-*` asset を対象にしない。また、read-only status / validation workflow を edit workflow に変えない。Kiro workflow ごとの分類、PR #90 由来の 6 点契約、generation-scoped gate の成果物境界、検証と smoke coverage を要求として定義する。
 
+この改訂では、`kiro-discovery` を単なる downstream delegation ではなく、discovery-owned artifact を書く workflow として扱う。`kiro-discovery` が `brief.md` や roadmap artifact を生成・更新する場合は、discovery 完了報告の前に discovery-scoped AI quality gate を通し、spec generation artifact 向けの gate とは別の境界で AI antipattern を検出・是正する。
+
 ## Boundary Context
 
-- **In scope（対象範囲）**: Kiro workflow coverage inventory、gate 適用対象と対象外の分類、generation / edit workflow の AI quality gate 契約、Kiro-specific facet の追加または更新、validator / test / smoke coverage による drift 検出、en/ja workflow parity。
-- **Out of scope（対象外）**: `cc-sdd-*` workflow、`opsx-*` workflow、OpenSpec-compatible workflow、upstream `.agents/skills/kiro-*` asset の直接変更、`CC-SDD-CODEX.md` の直接編集、read-only validation / status workflow への修正ループ追加、全 `kiro-*` workflow への機械的な `workflow_call` 挿入。
-- **Adjacent expectations（隣接システム／スペックへの期待）**: `kiro-ai-quality-gate` は初期 gate 契約と PR #90 の学びを提供し、`kiro-spec-generation-workflows` は generation workflow の既存 review / repair / finalize 境界を提供する。`kiro-shared-workflow-contracts` は workflow shape validation と callable subworkflow boundary を提供する。
+- **In scope（対象範囲）**: Kiro workflow coverage inventory、gate 適用対象と対象外の分類、generation / edit workflow の AI quality gate 契約、`kiro-discovery` の discovery artifact gate 契約、Kiro-specific facet の追加または更新、validator / test / smoke coverage による drift 検出、en/ja workflow parity。
+- **Out of scope（対象外）**: `cc-sdd-*` workflow、`opsx-*` workflow、OpenSpec-compatible workflow、upstream `.agents/skills/kiro-*` asset の直接変更、`CC-SDD-CODEX.md` の直接編集、read-only validation / status workflow への修正ループ追加、全 `kiro-*` workflow への機械的な `workflow_call` 挿入、`kiro-spec-batch` への artifact-level AI fix loop 追加。
+- **Adjacent expectations（隣接システム／スペックへの期待）**: `kiro-ai-quality-gate` は初期 gate 契約と PR #90 の学びを提供し、`kiro-spec-generation-workflows` は generation workflow の既存 review / repair / finalize 境界を提供する。`kiro-shared-workflow-contracts` は workflow shape validation と callable subworkflow boundary を提供する。`kiro-discovery` の gate は discovery-owned artifact だけを扱い、後続 spec generation workflow の artifact-level review を置き換えない。
 
 ## Project Description (Input)
 TAKT の Kiro workflow 開発者は、PR #90 で得た信頼性上の学びを `kiro-impl` 初期導入だけで終わらせず、他の Kiro workflow にも必要な範囲で適用したい。明示的な横展開境界がないと、他の Kiro write/edit または spec generation workflow では、domain-specific review gate の前に AI 特有のハルシネーション、スコープ逸脱、証跡不足、曖昧な review outcome、runtime wiring regressions を取りこぼす可能性が残る。
 
 現在、`kiro-ai-quality-gate` は callable subworkflow として存在し、`kiro-impl` に統合済みである。PR #90 では、次の 6 点が重要な契約として確認された: relative path による `workflow_call`、built-in `ai-antipattern-review` に合わせた routing vocabulary、ambiguous / blocked / inconsistent outcome 用の catch-all replan routing、optional な fix report、replan / repair 可能な loop exhaustion の非 `ABORT` 化、caller 側 `loop_monitors.cycle` への gate step 追加。
 
-この変更では、すべての Kiro workflow について PR #90 の 6 点に対する分類結果を持たせる。分類結果は、既存 gate で covered、generation-scoped gate が必要、orchestration として個別判断、read-only のため対象外、のいずれかである。gate 適用対象になった spec generation や edit workflow は、domain-specific review または finalize の前に適切な AI quality gate を通す。read-only な validation / status workflow は read-only のまま維持し、修正ループを追加しない。
+この変更では、すべての Kiro workflow について PR #90 の 6 点に対する分類結果を持たせる。分類結果は、既存 gate で covered、generation-scoped gate が必要、discovery artifact gate が必要、orchestration として個別判断、read-only のため対象外、のいずれかである。gate 適用対象になった spec generation、discovery artifact generation、edit workflow は、domain-specific review、discovery report、または finalize の前に適切な AI quality gate を通す。read-only な validation / status workflow は read-only のまま維持し、修正ループを追加しない。
 
 ## Requirements
 
@@ -28,7 +30,7 @@ TAKT の Kiro workflow 開発者は、PR #90 で得た信頼性上の学びを `
 #### Acceptance Criteria
 
 1. When Kiro AI quality gate coverage is evaluated, the TAKT Kiro workflow set shall classify every `.takt/{en,ja}/workflows/kiro-*` workflow into exactly one coverage category.
-2. The TAKT Kiro workflow set shall support coverage categories for existing gate coverage, generation-scoped gate required, orchestration-specific decision required, read-only out of scope, and intentionally not applicable.
+2. The TAKT Kiro workflow set shall support coverage categories for existing gate coverage, generation-scoped gate required, discovery artifact gate required, orchestration-specific decision required, read-only out of scope, and intentionally not applicable.
 3. When a workflow is classified as out of scope, the TAKT Kiro workflow set shall record the user-observable or operator-observable reason for that classification.
 4. If a Kiro workflow cannot be classified from available evidence, the TAKT Kiro workflow set shall report the workflow as requiring maintainer decision rather than silently treating it as covered.
 
@@ -43,6 +45,8 @@ TAKT の Kiro workflow 開発者は、PR #90 で得た信頼性上の学びを `
 3. Where a Kiro workflow performs orchestration or decomposition and may write planning artifacts, the TAKT Kiro workflow set shall require an explicit gate applicability decision before adding review/fix behavior.
 4. If applying the gate would change a workflow from read-only to edit-capable behavior, the TAKT Kiro workflow set shall reject that coverage plan.
 5. The TAKT Kiro workflow set shall not add AI quality gate calls to all `kiro-*` workflows mechanically.
+6. Where `kiro-discovery` writes discovery-owned `brief.md` or roadmap artifacts, the TAKT Kiro workflow set shall treat those artifacts as eligible for discovery-scoped AI quality gate evaluation.
+7. The TAKT Kiro workflow set shall keep discovery-scoped gate findings separate from implementation-scoped fix instructions.
 
 ### Requirement 3: PR #90 の 6 点契約を gate 適用対象に要求する
 
@@ -56,6 +60,7 @@ TAKT の Kiro workflow 開発者は、PR #90 で得た信頼性上の学びを `
 4. When the first AI antipattern review finds no blocking issue, the TAKT Kiro workflow set shall allow completion without requiring a fix report.
 5. If an AI review/fix loop reaches its threshold while replan or repair remains possible, the TAKT Kiro workflow set shall return the corresponding replan or repair outcome instead of bluntly aborting.
 6. When a caller workflow inserts an AI quality gate step into an existing monitored cycle, the TAKT Kiro workflow set shall include that gate step in the caller's loop monitor cycle.
+7. When `kiro-discovery` calls an AI quality gate subworkflow, the TAKT Kiro workflow set shall apply the same routing and loop contracts to discovery-specific outcomes.
 
 ### Requirement 4: Generation-scoped gate は spec artifact の境界を守る
 
@@ -80,18 +85,21 @@ TAKT の Kiro workflow 開発者は、PR #90 で得た信頼性上の学びを `
 3. When no fix report exists because the first AI antipattern review found no blocking issue, the downstream Kiro review or finalize step shall not treat the missing fix report as a failure.
 4. If downstream review rejects AI quality gate evidence, the TAKT Kiro workflow set shall route through the workflow's existing repair, replan, or blocked path.
 5. The TAKT Kiro workflow set shall keep progress or lifecycle promotion dependent on the appropriate verified review/finalize result rather than making promotion steps re-review raw gate reports independently.
+6. When `kiro-discovery` produces a discovery report after writing artifacts, the discovery report step shall account for unresolved discovery-scoped AI antipattern findings before reporting completion.
 
-### Requirement 6: read-only と orchestration workflow の対象外境界を維持する
+### Requirement 6: discovery artifact gate と read-only / orchestration 境界を維持する
 
-**Objective:** TAKT Kiro workflow maintainer として、品質ゲート横展開によって既存 workflow の責務を崩したくない。そうすることで、status、validation、discovery、batch の operator expectations を壊さずに coverage を増やせる。
+**Objective:** TAKT Kiro workflow maintainer として、品質ゲート横展開によって既存 workflow の責務を崩したくない。そうすることで、status、validation、batch の operator expectations を壊さず、`kiro-discovery` が所有する discovery artifact には必要な AI quality gate coverage を追加できる。
 
 #### Acceptance Criteria
 
 1. While `kiro-spec-status` or `kiro-validate-*` workflows remain read-only, the TAKT Kiro workflow set shall not add edit-capable AI fix behavior to those workflows.
-2. Where `kiro-discovery` writes brief or roadmap artifacts, the TAKT Kiro workflow set shall classify whether AI quality gate coverage belongs to discovery output review or to a later spec generation phase.
-3. Where `kiro-spec-batch` orchestrates worker results and cross-spec review, the TAKT Kiro workflow set shall classify whether AI quality gate coverage belongs to worker generation workflows, batch aggregation, or neither.
-4. If a workflow is classified as orchestration-only out of scope, the TAKT Kiro workflow set shall document the adjacent workflow that owns artifact-level AI quality review.
-5. The TAKT Kiro workflow set shall keep roadmap checkbox markers out of implementation progress decisions when classifying coverage.
+2. When `kiro-discovery` writes `brief.md` or roadmap artifacts, the TAKT Kiro workflow set shall evaluate discovery-scoped AI quality before reporting discovery complete.
+3. If `kiro-discovery` AI quality findings can be corrected within discovery-owned artifacts, the TAKT Kiro workflow set shall route through discovery-scoped repair before completion.
+4. If `kiro-discovery` AI quality findings require different decomposition, existing spec ownership changes, or human clarification, the TAKT Kiro workflow set shall route to replan or maintainer-decision behavior instead of silently editing unrelated spec artifacts.
+5. Where `kiro-spec-batch` orchestrates worker results and cross-spec review, the TAKT Kiro workflow set shall classify whether AI quality gate coverage belongs to worker generation workflows, batch aggregation, or neither.
+6. If a workflow is classified as orchestration-only out of scope, the TAKT Kiro workflow set shall document the adjacent workflow that owns artifact-level AI quality review.
+7. The TAKT Kiro workflow set shall keep roadmap checkbox markers out of implementation progress decisions when classifying coverage.
 
 ### Requirement 7: Validation と smoke coverage で drift を検出する
 
@@ -104,6 +112,8 @@ TAKT の Kiro workflow 開発者は、PR #90 で得た信頼性上の学びを `
 3. When repository validation runs, the TAKT Kiro workflow set shall detect drift from the relative `workflow_call`, routing vocabulary, catch-all routing, optional fix report, loop exhaustion, and caller loop monitor contracts.
 4. When runtime smoke coverage runs for AI quality gate wiring, the TAKT Kiro workflow set shall exercise at least one deterministic successful gate path for a covered workflow.
 5. If validator or smoke coverage cannot determine whether a workflow is covered or intentionally out of scope, the TAKT Kiro workflow set shall fail with an actionable classification finding.
+6. When repository validation runs, the TAKT Kiro workflow set shall detect missing discovery-scoped AI quality gate coverage for `kiro-discovery`.
+7. When repository validation runs, the TAKT Kiro workflow set shall detect implementation-scoped fix instructions wired into `kiro-discovery` discovery artifact review.
 
 ### Requirement 8: Language parity と upstream asset 境界を守る
 

--- a/.kiro/specs/kiro-ai-quality-gate-workflow-coverage/research.md
+++ b/.kiro/specs/kiro-ai-quality-gate-workflow-coverage/research.md
@@ -1,305 +1,145 @@
-# Gap Analysis: kiro-ai-quality-gate-workflow-coverage
-
-## Analysis Context
-
-- **Feature**: `kiro-ai-quality-gate-workflow-coverage`
-- **Date**: 2026-06-08
-- **Requirements status**: `requirements-generated`, not yet approved
-- **Analysis scope**: `.takt/{en,ja}/workflows/kiro-*`, related Kiro facets, repository validators, and tests
-- **External research**: Not needed. The feature is a brownfield TAKT workflow/facet/validator change using existing local runtime and built-in assets.
-
-## Current State Summary
-
-The repository already has a callable `kiro-ai-quality-gate` integrated into `kiro-impl`. That implementation covers the PR #90 lessons for implementation output:
-
-- `kiro-impl` routes `execute-task -> ai-quality-gate -> review-task`.
-- The caller uses `kind: workflow_call` and `call: ./kiro-ai-quality-gate.yaml`.
-- `kiro-ai-quality-gate` uses built-in `ai-antipattern-reviewer`, `ai-antipattern`, `ai-antipattern-review`, and `loop-monitor-ai-antipattern-fix`.
-- `kiro-impl` review / verify facets consume `kiro-ai-antipattern-review.md` and optional `kiro-ai-antipattern-fix.md`.
-- `tests/kiro-ai-quality-gate-runtime-smoke.test.mjs` validates one deterministic runtime path through `npm run kiro:impl`.
-
-The remaining Kiro workflow set has no comparable coverage inventory or generation-scoped AI gate:
-
-- Generation workflows: `kiro-spec-requirements`, `kiro-spec-design`, `kiro-spec-tasks`, `kiro-spec-quick`.
-- Single-step generation/init workflow: `kiro-spec-init`.
-- Orchestration/decomposition workflows: `kiro-discovery`, `kiro-spec-batch`.
-- Read-only workflows: `kiro-spec-status`, `kiro-validate-design`, `kiro-validate-gap`, `kiro-validate-impl`.
-
-## Requirement-to-Asset Map
-
-| Requirement | Existing assets | Gap |
-|---|---|---|
-| R1 coverage inventory | Kiro workflow files exist in both `.takt/en` and `.takt/ja`; validators enumerate Kiro workflows | Missing: explicit coverage category for every Kiro workflow |
-| R2 eligibility by artifact boundary | Workflow YAML has `edit: true/false`; read-only validators reject edit behavior in status/validate workflows | Missing: eligibility model that distinguishes generation, implementation, orchestration, and read-only |
-| R3 PR #90 six contracts | `kiro-iterative-implementation` validator enforces most six contracts for `kiro-impl`; shared validator allows only current call site | Missing: generalized validation for additional eligible Kiro callers |
-| R4 generation-scoped gate | Spec generation workflows already have generate/review/repair/finalize loops | Missing: AI antipattern gate before domain review/finalize and generation-scoped fix instruction |
-| R5 downstream evidence consumption | `kiro-review-task` and `kiro-verify-task-completion` consume implementation gate reports | Missing: equivalent evidence consumption rules for spec generation review/finalize steps |
-| R6 read-only/orchestration boundary | `validate-kiro-status-validation-workflows` and shared validator enforce read-only shape | Missing: documented classification for discovery/batch and protection against mechanical gate insertion |
-| R7 validator/smoke coverage | Existing validators and runtime smoke cover `kiro-impl`; test patterns are available | Missing: coverage validator and at least one deterministic smoke path for generation-scoped gate |
-| R8 language/upstream boundary | en/ja parity patterns and `TAKT.md` policy exist | Missing: parity checks for new gate coverage assets and classification docs |
-
-## Existing Implementation Details
-
-### Kiro implementation gate
-
-Relevant assets:
-
-- `.takt/{en,ja}/workflows/kiro-ai-quality-gate.yaml`
-- `.takt/{en,ja}/workflows/kiro-impl.yaml`
-- `.takt/{en,ja}/facets/instructions/kiro-ai-antipattern-fix-implementation.md`
-- `.takt/{en,ja}/facets/output-contracts/kiro-ai-antipattern-fix-result.md`
-- `.takt/{en,ja}/facets/instructions/kiro-review-task.md`
-- `.takt/{en,ja}/facets/instructions/kiro-verify-task-completion.md`
-- `scripts/validate-kiro-iterative-implementation-workflow.mjs`
-- `tests/kiro-iterative-implementation-workflow.test.mjs`
-- `tests/kiro-ai-quality-gate-runtime-smoke.test.mjs`
-
-The current gate is reusable at the workflow schema level because it accepts `fix_instruction` and `domain_knowledge` as facet refs. However, the current workflow description, report names, and validator assumptions are implementation-centered. The existing fix instruction explicitly targets implementation scope and forbids progress artifact updates. This should not be blindly reused for requirements/design/tasks drafts.
-
-### Kiro spec generation workflows
-
-Relevant workflows:
-
-- `kiro-spec-requirements`: `generate-requirements -> review-requirements -> repair-requirements -> finalize-requirements`
-- `kiro-spec-design`: `generate-design -> review-design -> repair-design -> finalize-design`
-- `kiro-spec-tasks`: `generate-tasks -> review-tasks -> repair-tasks -> finalize-tasks`
-- `kiro-spec-quick`: expanded sequence for init, requirements, design, tasks, sanity review
-
-These workflows already defer artifact writing and lifecycle promotion until review/finalize boundaries:
-
-- Draft generation/repair steps return draft content and keep `updatedFiles` empty.
-- Dedicated read-only review steps inspect draft content.
-- Finalize steps write artifacts and update `spec.json`.
-- `loop_monitors.threshold` owns retry bounds.
-
-This shape is a good insertion point for AI quality checks, but gate placement needs care. The least disruptive candidate is between draft generation/repair and domain review:
-
-- `generate-requirements -> ai-quality-gate -> review-requirements`
-- `repair-requirements -> ai-quality-gate -> review-requirements`
-- analogous design/tasks/quick phase paths
-
-If the gate is placed after domain review, AI-specific defects may be found too late, after the domain reviewer has already spent effort. If placed before draft readiness, the gate may not have stable artifacts to inspect.
-
-### Read-only workflows
-
-Relevant workflows:
-
-- `kiro-spec-status`
-- `kiro-validate-design`
-- `kiro-validate-gap`
-- `kiro-validate-impl`
-
-These already follow read-only collect/classify-or-validate/report shapes and validators reject:
-
-- `loop_monitors`
-- `edit: true`
-- `required_permission_mode: edit`
-- repair/debug steps
-- nested Kiro workflow calls
-
-They should remain out of AI fix loop scope. A validator should detect accidental gate insertion here.
-
-### Orchestration workflows
-
-Relevant workflows:
-
-- `kiro-discovery`
-- `kiro-spec-batch`
-
-`kiro-discovery` can write `brief.md` and roadmap artifacts. `kiro-spec-batch` orchestrates dependency waves, worker dispatch, cross-spec review, remediation coordination, and batch finalization. These are not pure read-only workflows, but their responsibility is not identical to requirements/design/tasks artifact generation.
-
-The likely design posture is:
-
-- classify them explicitly;
-- do not add the generation gate mechanically;
-- decide whether artifact-level AI review belongs inside discovery/batch or is delegated to downstream spec generation workflows.
-
-## Validator Constraints and Integration Risks
-
-### Shared workflow_call boundary
-
-`scripts/validate-kiro-shared-contracts.mjs` currently allows exactly one Kiro `workflow_call`: the `ai-quality-gate` step in `kiro-impl.yaml` with `call: ./kiro-ai-quality-gate.yaml`. Any new Kiro caller will fail unless this allowlist evolves.
-
-Risk: simply adding `workflow_call` to spec generation workflows will break shared validation.
-
-Design implication: introduce an explicit allowlist model keyed by workflow name, step name, and relative call path, and keep every other nested Kiro workflow call forbidden.
-
-### Spec generation workflow_call prohibition
-
-`scripts/validate-kiro-spec-generation-workflows.mjs` rejects `workflow_call` in `kiro-spec-quick.yaml` to prevent quick path from delegating to standalone workflows. That rule is correct for phase reuse, but it will conflict with an AI gate if implemented via `workflow_call` inside quick.
-
-Risk: a naive gate insertion into `kiro-spec-quick` will trip an existing validator that was designed for a different failure mode.
-
-Design implication: either narrow the prohibition to phase workflow calls, or implement quick AI gate coverage as expanded steps instead of `workflow_call`. The design must preserve the intent that quick does not shell out or call standalone phase workflows.
-
-### Existing implementation validator is gate-specific
-
-`validate-kiro-iterative-implementation-workflow.mjs` contains detailed checks for:
-
-- `kiro-impl` caller routing;
-- `kiro-ai-quality-gate` shape;
-- built-in review vocabulary;
-- optional fix report semantics;
-- loop monitor and replan routing;
-- runtime smoke alignment.
-
-Risk: duplicating this logic for generation workflows could create parallel validator drift and large spaghetti condition growth.
-
-Design implication: factor reusable validation helpers or create a dedicated Kiro AI gate coverage validator that shares the contract terms instead of copy-pasting checks into multiple validators.
-
-## Gaps
-
-### Missing capabilities
-
-- No coverage inventory artifact or validator-backed classification for all Kiro workflows.
-- No generation-scoped AI fix instruction.
-- No generation-scoped AI fix output contract if implementation fix result semantics are too task-specific.
-- No caller routing for AI quality gate in spec generation workflows.
-- No downstream generation review/finalize evidence consumption rules for AI gate reports.
-- No validator coverage for eligible generation workflows bypassing gate coverage.
-- No deterministic runtime smoke for generation-scoped AI gate wiring.
-- No updated shared `workflow_call` boundary model for multiple approved gate call sites.
-
-### Constraints
-
-- Read-only validation/status workflows must stay read-only.
-- Quick path must not use `workflow_call` for phase reuse or shell out to nested `takt`.
-- `cc-sdd-*`, `opsx-*`, OpenSpec-compatible workflows, and upstream `.agents/skills/kiro-*` are out of scope.
-- en/ja assets must remain structurally aligned.
-- Prompt prose is insufficient; validation/test coverage must enforce the wiring.
-
-### Research Needed in design phase
-
-- Decide whether the existing `kiro-ai-quality-gate.yaml` should become scope-neutral through parameterized fix instructions, or whether a separate `kiro-spec-ai-quality-gate.yaml` is cleaner.
-- Decide report naming for generation-scoped AI reports to avoid ambiguity between implementation and generation runs.
-- Decide whether `kiro-spec-init` should be covered by a gate or explicitly classified as not applicable due to minimal template-based initialization.
-- Decide whether `kiro-discovery` and `kiro-spec-batch` own any AI quality gate behavior or only classify/delegate to downstream generation workflows.
-
-## Implementation Options
-
-### Option A: Extend existing `kiro-ai-quality-gate`
-
-Extend the existing callable gate by passing a generation-specific `fix_instruction` and domain knowledge. Keep one gate workflow and add callers from eligible generation workflows.
-
-**Pros**
-
-- Reuses PR #90 runtime-proven callable workflow.
-- Minimizes new workflow files.
-- Keeps the six-contract implementation in one place.
-
-**Cons**
-
-- Current gate name, description, reports, and validator checks are implementation-colored.
-- A single gate may accumulate conditional language for implementation vs generation scope.
-- Quick path and shared workflow_call validators still need careful allowlist updates.
-
-**Effort**: M  
-**Risk**: Medium. Good reuse, but risk of overgeneralizing the implementation gate.
-
-### Option B: Create a generation-scoped callable gate
-
-Add `kiro-spec-ai-quality-gate.yaml` with generation-specific fix instruction and report semantics. Use it only from requirements/design/tasks generation workflows and potentially quick.
-
-**Pros**
-
-- Keeps implementation and spec generation boundaries explicit.
-- Avoids overloading implementation fix report semantics.
-- Makes downstream review/finalize evidence rules easier to state.
-
-**Cons**
-
-- More files and more validator coverage.
-- Some six-contract checks will be duplicated unless helpers are extracted.
-- Runtime smoke must cover at least one new generation path.
-
-**Effort**: M to L  
-**Risk**: Medium. Cleaner boundary, but more integration points.
-
-### Option C: Inventory and validator first, gate rollout second
-
-First implement the coverage inventory and validators that classify all Kiro workflows and detect illegal gate placement. Then add generation-scoped gate coverage in a follow-up.
-
-**Pros**
-
-- Reduces risk of mechanical over-application.
-- Forces explicit discovery/batch/init/read-only decisions before wiring changes.
-- Can be small and reviewable.
-
-**Cons**
-
-- Does not immediately protect generation artifacts.
-- Requires a second implementation slice.
-
-**Effort**: S to M  
-**Risk**: Low. Primarily validation/documentation, less runtime behavior change.
-
-### Option D: Hybrid rollout
-
-Implement an explicit coverage inventory and validator model first, then add generation-scoped gate coverage for the highest-value generation workflows (`kiro-spec-requirements`, `kiro-spec-design`, `kiro-spec-tasks`) in the same spec. Treat `kiro-spec-quick`, `kiro-spec-init`, `kiro-discovery`, and `kiro-spec-batch` as explicit design decisions rather than automatic targets.
-
-**Pros**
-
-- Balances behavior change with classification safety.
-- Keeps design from pushing gate calls into every workflow.
-- Provides immediate value on the main generation phases.
-- Leaves quick/discovery/batch ambiguity visible instead of hidden.
-
-**Cons**
-
-- More design decisions than Option C.
-- Needs careful validator refactoring to avoid duplicated gate checks.
-
-**Effort**: L  
-**Risk**: Medium. Broad but bounded; best aligned with requirements.
-
-## Recommended Direction for Design
-
-Use Option D unless the design phase finds `workflow_call` validator changes too invasive. The design should:
-
-- introduce an explicit Kiro AI gate coverage inventory;
-- make workflow eligibility a first-class validation concept;
-- prefer a generation-scoped gate or clearly parameterized shared gate over reusing the implementation fix instruction blindly;
-- update shared workflow_call boundary checks through an allowlist rather than weakening the nested workflow ban;
-- protect read-only workflows with negative tests;
-- add one deterministic runtime smoke path for generation-scoped gate wiring;
-- keep quick/discovery/batch decisions explicit and conservative.
-
-## Complexity and Risk
-
-- **Effort**: L. The feature spans workflow YAML, facets, validators, tests, and runtime smoke coverage across en/ja assets.
-- **Risk**: Medium. The behavior change is constrained to Kiro workflows, but validator allowlists and quick path composition rules can regress if broadened carelessly.
-
-## Open Questions for Design
-
-1. Should generation-scoped gate reports reuse `kiro-ai-antipattern-review.md` / `kiro-ai-antipattern-fix.md`, or use phase-specific names such as `kiro-spec-ai-antipattern-review.md`?
-2. Should `kiro-spec-quick` call a gate subworkflow or inline equivalent gate steps to preserve the existing quick-path no-workflow-call rule?
-3. Is `kiro-spec-init` sufficiently template-bound to classify as intentionally not applicable?
-4. Should `kiro-discovery` output be AI-reviewed in discovery, or should `brief.md` risk be handled when `kiro-spec-init` / generation reads it?
-5. Should `kiro-spec-batch` only aggregate worker results and delegate artifact-level AI review to the generation workers?
+# Research & Design Decisions
+
+## Summary
+
+- **Feature（機能）**: `kiro-ai-quality-gate-workflow-coverage`
+- **Discovery Scope（ディスカバリー範囲）**: Extension
+- **Key Findings（主要な発見）**:
+  - 既存の generation-scoped gate は `kiro-spec-ai-quality-gate.yaml` と validator/test で実装済みだが、`kiro-discovery` はまだ `orchestration_delegated` として扱われている。
+  - `kiro-discovery` は `write-discovery-artifacts` だけが edit-capable で、successful artifact write path は現在 `report-discovery` へ直行する。
+  - `validate-kiro-discovery-batch-workflows.mjs` は `workflow_call` を一律禁止しているため、discovery gate を入れるには allowlist 化が必要である。
+
+## Research Log
+
+### Existing coverage inventory and validators
+
+- **Context（背景）**: requirements 改訂で `kiro-discovery` が discovery artifact gate required へ変わったため、既存 classification と validator の変更点を確認した。
+- **Sources Consulted（参照した情報源）**:
+  - `scripts/kiro-ai-quality-gate-contracts.mjs`
+  - `scripts/validate-kiro-ai-quality-gate-workflow-coverage.mjs`
+  - `tests/kiro-ai-quality-gate-workflow-coverage.test.mjs`
+- **Findings（発見）**:
+  - category set には `discovery_artifact_gate_required` がまだない。
+  - `kiro-discovery` は `orchestration_delegated`、`allowedGateCall` なしで固定されている。
+  - 新規 `kiro-discovery-ai-quality-gate` も `.takt/{en,ja}/workflows/kiro-*` に該当するため、coverage inventory に callable gate 自体として分類する必要がある。
+  - tests は discovery/batch の direct gate absence を期待している。
+- **Implications（含意）**:
+  - coverage inventory を machine-readable 正本として更新する。
+  - `kiro-discovery-ai-quality-gate` は `existing_gate_coverage` に分類し、全 workflow exactly once invariant を維持する。
+  - `kiro-spec-batch` の delegated classification は維持し、discovery だけを gate required に移す。
+  - tests は discovery direct gate を positive expectation に変更し、batch direct gate absence を negative expectation として残す。
+
+### Kiro discovery workflow insertion point
+
+- **Context（背景）**: discovery gate をどこへ挿入するかを、既存 workflow 責務から判断した。
+- **Sources Consulted（参照した情報源）**:
+  - `.takt/{en,ja}/workflows/kiro-discovery.yaml`
+  - `.takt/{en,ja}/facets/instructions/kiro-discovery.md`
+  - `.takt/{en,ja}/facets/output-contracts/kiro-discovery-result.md`
+- **Findings（発見）**:
+  - `classify-action-path` と `plan-discovery-artifacts` は readonly である。
+  - `write-discovery-artifacts` は edit-capable で、artifact write 成功後に `report-discovery` へ進む。
+  - artifact-less paths は discovery gate を通す必要がない。
+- **Implications（含意）**:
+  - gate は `write-discovery-artifacts` の successful artifact write path と `report-discovery` の間へ挿入する。
+  - `need_replan` は `plan-discovery-artifacts` に戻るため、caller workflow 側で `plan-discovery-artifacts -> write-discovery-artifacts -> ai-quality-gate-discovery` の loop monitor を定義する必要がある。
+  - `report-discovery` は namespaced discovery gate reports を確認してから completion を報告する。
+  - loop monitor threshold に到達した場合は、追加修正を続けず blocked discovery result として報告する。
+
+### Workflow call boundary
+
+- **Context（背景）**: `kiro-discovery` に reusable subworkflow を挿入すると、既存 discovery/batch validator と shared validator に影響する。
+- **Sources Consulted（参照した情報源）**:
+  - `scripts/validate-kiro-shared-contracts.mjs`
+  - `scripts/validate-kiro-discovery-batch-workflows.mjs`
+  - `.takt/{en,ja}/workflows/kiro-spec-ai-quality-gate.yaml`
+- **Findings（発見）**:
+  - shared validator は helper 由来の allowed call sites を既に扱う。
+  - discovery/batch validator は `workflow_call` を一律禁止している。
+  - generation gate は implementation gate と分離され、report names と fix instruction を分けている。
+- **Implications（含意）**:
+  - discovery/batch validator は一律禁止から approved discovery gate call だけを許可する allowlist check に変える。
+  - phase reuse、shell `takt -w`、`kiro-spec-batch` direct gate は引き続き禁止する。
+  - discovery gate は implementation/spec report names を再利用しない。
+
+## Architecture Pattern Evaluation
+
+| Option | Description | Strengths | Risks / Limitations | Notes |
+|---|---|---|---|---|
+| Reuse implementation gate | `kiro-ai-quality-gate.yaml` を discovery 用 `fix_instruction` で呼ぶ | ファイル数が少ない | report names と implementation progress policy が混ざる | 不採用 |
+| Reuse spec generation gate | `kiro-spec-ai-quality-gate.yaml` を discovery から呼ぶ | 既存 gate を再利用できる | spec artifact boundary と discovery artifact boundary が混ざる | 不採用 |
+| Dedicated discovery gate | `kiro-discovery-ai-quality-gate.yaml` を追加する | 境界、report names、fix instruction が明確 | 追加ファイルと validator 更新が必要 | 採用 |
+| Inline gate steps | `kiro-discovery.yaml` に review/fix steps を直接追加する | `workflow_call` validator 変更が不要 | reusable subworkflow 化できず、PR #90 shared contract を使いにくい | 不採用 |
+
+## Design Decisions
+
+### Decision: Discovery gate は専用 callable subworkflow にする
+
+- **Context（背景）**: `kiro-discovery` の成果物は `brief.md` と roadmap であり、implementation task や spec generation draft と違う境界を持つ。
+- **Alternatives Considered（検討した代替案）**:
+  1. implementation gate を parameterized に再利用する。
+  2. spec generation gate を discovery から呼ぶ。
+  3. dedicated discovery gate を作る。
+- **Selected Approach（採用したアプローチ）**: `kiro-discovery-ai-quality-gate.yaml` を en/ja に追加し、`kiro-ai-antipattern-fix-discovery` と discovery-specific report names を使う。
+- **Rationale（根拠）**: discovery artifact 境界を実装・spec generation 境界から分離でき、validator が誤配線を検出しやすい。
+- **Trade-offs（トレードオフ）**: ファイルは増えるが、TAKT の reusable subworkflow 機能を使いながら semantic overloading を避けられる。
+- **Follow-up（フォローアップ）**: runtime smoke で clean path を確認する。
+
+### Decision: Discovery replan は caller loop monitor で収束管理する
+
+- **Context（背景）**: discovery gate の `need_replan` は `plan-discovery-artifacts` に戻るため、caller 側に `plan -> write -> gate` の循環ができる。
+- **Alternatives Considered（検討した代替案）**:
+  1. `need_replan` を常に `ABORT` にする。
+  2. `max_steps` だけに任せる。
+  3. caller loop monitor で収束管理する。
+- **Selected Approach（採用したアプローチ）**: `kiro-discovery` に `plan-discovery-artifacts`、`write-discovery-artifacts`、`ai-quality-gate-discovery` を含む loop monitor を追加し、threshold 到達時は blocked discovery result へ進める。
+- **Rationale（根拠）**: PR #90 の caller loop monitor 契約を discovery にも適用でき、replan 可能な issue と非収束 issue を分離できる。
+- **Trade-offs（トレードオフ）**: discovery workflow は loop monitor を持つが、read-only workflow ではなく artifact-writing workflow なので責務境界には反しない。
+- **Follow-up（フォローアップ）**: validator と smoke test で cycle membership と threshold path を検証する。
+
+### Decision: `kiro-discovery` は gate required、`kiro-spec-batch` は delegated のままにする
+
+- **Context（背景）**: discovery は自分で planning artifacts を書くが、batch は worker generation workflows を orchestrate する。
+- **Alternatives Considered（検討した代替案）**:
+  1. discovery と batch の両方に direct gate を入れる。
+  2. discovery だけを gate required にする。
+  3. 両方とも downstream delegation のままにする。
+- **Selected Approach（採用したアプローチ）**: discovery は `discovery_artifact_gate_required`、batch は `orchestration_delegated` にする。
+- **Rationale（根拠）**: requirements の discovery artifact gate 要求を満たしつつ、batch の worker ownership を崩さない。
+- **Trade-offs（トレードオフ）**: batch aggregation 自体の AI review は今後の別判断として残る。
+- **Follow-up（フォローアップ）**: coverage validator で batch direct gate absence を維持する。
+
+### Decision: Discovery validator は allowlist 化する
+
+- **Context（背景）**: 既存 discovery/batch validator は `workflow_call` を phase reuse 防止目的で一律禁止している。
+- **Alternatives Considered（検討した代替案）**:
+  1. `workflow_call` 禁止を削除する。
+  2. discovery gate だけを helper allowlist で許可する。
+  3. inline steps にして validator を変えない。
+- **Selected Approach（採用したアプローチ）**: helper の allowed call sites に `kiro-discovery` gate call を追加し、validator はその call だけを許可する。
+- **Rationale（根拠）**: reusable subworkflow を使いつつ、phase reuse と mechanical gate insertion を引き続き検出できる。
+- **Trade-offs（トレードオフ）**: validator が helper に依存するが、contract drift は一箇所で管理できる。
+- **Follow-up（フォローアップ）**: negative tests で unapproved call path と batch direct gate を検出する。
 
 ## Design Synthesis Update
 
-### Discovery Type
+- Generalization: implementation/spec/discovery gates は separate workflows だが、allowed call site、routing vocabulary、optional fix report、loop outcome terms は shared helper で一般化する。
+- Build vs Adopt: 外部依存は追加せず、TAKT `workflow_call`、built-in `ai-antipattern-reviewer`、Node.js `node:test` を採用する。
+- Simplification: discovery gate は artifact write success path だけに置き、artifact-less discovery paths には追加しない。
+- Boundary correction: 新規 callable gate も Kiro workflow inventory の対象であるため、`kiro-discovery-ai-quality-gate` を `existing_gate_coverage` として classified workflow に含める。
 
-Light discovery was sufficient because this is an extension of existing TAKT workflow, facet, validator, and test assets. No new external dependency is introduced.
+## Risks & Mitigations
 
-### Decisions
+- `kiro-discovery` が implementation fix instruction を誤って使う — coverage validator で forbidden instruction/report names を検出する。
+- discovery/batch validator の `workflow_call` 禁止を弱めすぎる — helper allowlist の exact match だけを許可する。
+- discovery gate が spec artifact へ越境修正する — fix instruction と output contract に boundary guard を入れ、report validation で検出する。
+- discovery replan が非収束ループになる — caller loop monitor で `plan-discovery-artifacts`、`write-discovery-artifacts`、`ai-quality-gate-discovery` の cycle を監視する。
+- runtime smoke が通常 provider を起動する — mock provider path を opt-in にし、CI では deterministic fixture だけを使う。
 
-- Use a separate `kiro-spec-ai-quality-gate.yaml` rather than making the implementation gate scope-neutral. This keeps implementation progress semantics separate from spec generation draft semantics.
-- Use generation-specific report names: `kiro-spec-ai-antipattern-review.md` and optional `kiro-spec-ai-antipattern-fix.md`. This avoids ambiguity when a run contains both implementation and spec generation evidence.
-- Keep `kiro-spec-quick` on the reusable subworkflow path, but narrow the existing validator prohibition: quick still must not call standalone phase workflows, while `./kiro-spec-ai-quality-gate.yaml` is the only allowed gate call.
-- Classify `kiro-spec-init` as intentionally not applicable because it initializes the spec shell from brief/template inputs and does not have a stable generated draft review boundary.
-- Classify `kiro-discovery` and `kiro-spec-batch` as orchestration delegated. Discovery/batch do not gain artifact-level AI fix loops in this spec; downstream spec generation workflows own artifact-level gate coverage.
-- Put the authoritative machine-readable coverage inventory and call allowlist in `scripts/kiro-ai-quality-gate-contracts.mjs`. Keep `.takt/{en,ja}/facets/policies/kiro-ai-quality-gate-coverage.md` as a human-facing explanation of category semantics and decision criteria, not as a duplicated per-workflow classification table.
+## References
 
-### Boundary Synthesis
-
-The main boundary is not "all Kiro workflows get a gate." The boundary is "workflow outputs that become spec artifacts through generation/review/finalize get a generation-scoped AI gate, and every other Kiro workflow gets an explicit classification." This preserves read-only workflows and prevents orchestration workflows from silently becoming edit/fix workflows.
-
-Coverage classification has one canonical machine source. The policy facet explains the meaning of the categories and how operators should reason about them, but does not duplicate the workflow-by-workflow table.
-
-### Implementation Risk Notes
-
-- `validate-kiro-shared-contracts.mjs` currently allows only the `kiro-impl` call site. The design requires an allowlist helper rather than weakening the nested workflow ban.
-- `validate-kiro-spec-generation-workflows.mjs` currently rejects `workflow_call` in `kiro-spec-quick.yaml`. The design narrows that check to reject phase workflow reuse while allowing the single approved AI quality gate call.
-- The validator surface can grow quickly if every script copies PR #90 checks. The design centralizes contract vocabulary and allowed call sites in one helper to avoid validator drift.
+- `.kiro/specs/kiro-ai-quality-gate-workflow-coverage/requirements.md`
+- `.takt/{en,ja}/workflows/kiro-discovery.yaml`
+- `.takt/{en,ja}/workflows/kiro-spec-ai-quality-gate.yaml`
+- `scripts/kiro-ai-quality-gate-contracts.mjs`
+- `scripts/validate-kiro-discovery-batch-workflows.mjs`

--- a/.kiro/specs/kiro-ai-quality-gate-workflow-coverage/spec.json
+++ b/.kiro/specs/kiro-ai-quality-gate-workflow-coverage/spec.json
@@ -1,7 +1,7 @@
 {
   "feature_name": "kiro-ai-quality-gate-workflow-coverage",
   "created_at": "2026-06-08T09:14:17Z",
-  "updated_at": "2026-06-08T11:31:39Z",
+  "updated_at": "2026-06-08T16:46:53Z",
   "language": "ja",
   "phase": "tasks-generated",
   "approvals": {

--- a/.kiro/specs/kiro-ai-quality-gate-workflow-coverage/tasks.md
+++ b/.kiro/specs/kiro-ai-quality-gate-workflow-coverage/tasks.md
@@ -1,112 +1,112 @@
 # Implementation Plan
 
-- [ ] 1. Coverage foundation と shared gate contract を固定する
-- [x] 1.1 Kiro workflow coverage inventory の正本と人間向け判断基準を定義する
-  - すべての Kiro workflow が exactly one category を持ち、対象外 workflow には operator が読める理由がある状態にする。
-  - `kiro-impl`、spec generation、quick、init、discovery、batch、status/validate の分類が design の category と一致していることを確認できる。
-  - workflow ごとの分類は machine-readable helper を正本にし、policy facet は分類表を再掲せず category semantics と判断基準だけを説明する。
-  - roadmap checkbox marker を implementation progress 判定に使わない分類根拠を明示する。
-  - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 2.5, 6.2, 6.3, 6.4, 6.5, 8.3_
+- [x] 1. Coverage inventory と shared gate contract を discovery 対応へ更新する
+- [x] 1.1 Coverage inventory に discovery gate category と callable gate 分類を追加する
+  - `kiro-discovery` が `discovery_artifact_gate_required` として分類され、`kiro-discovery-ai-quality-gate` が callable gate 自体として `existing_gate_coverage` に分類される。
+  - `kiro-spec-batch` は `orchestration_delegated` のまま、adjacent owner が worker generation workflows として記録される。
+  - すべての `.takt/{en,ja}/workflows/kiro-*` が exactly once で分類され、未分類 workflow は maintainer decision finding になる。
+  - roadmap checkbox marker を implementation progress 判定に使わない分類根拠が維持される。
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 6.5, 6.6, 6.7, 8.3_
   - _Boundary:_ CoverageInventoryContract
   - _Depends:_ none
 
-- [x] 1.2 PR #90 の 6 点契約と allowed gate call sites を共有契約として定義する
-  - implementation gate と generation gate の allowed call site が workflow name、step name、relative call path で表現される状態にする。
-  - bare workflow name call、未分類 caller、read-only caller を拒否するための contract terms が揃っている状態にする。
-  - routing vocabulary、catch-all routing、optional fix report、loop exhaustion、caller loop monitor membership の検証語彙が 1 箇所から参照できる。
-  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 7.3_
+- [x] 1.2 Shared gate contract に discovery call site と report terms を追加する
+  - allowed gate call site に `kiro-discovery` / `ai-quality-gate-discovery` / `./kiro-discovery-ai-quality-gate.yaml` / `discovery_artifact` が追加される。
+  - implementation、spec generation、discovery の report names と optional fix report names が gate kind ごとに区別される。
+  - relative `workflow_call`、built-in routing vocabulary、catch-all routing、optional fix report、loop outcome、caller loop monitor membership の検証語彙が 1 箇所から参照できる。
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 7.3, 8.2_
   - _Boundary:_ SharedGateContractHelper
   - _Depends:_ 1.1
 
-- [ ] 2. Generation-scoped AI quality gate と facet 契約を作る
-- [x] 2.1 spec generation draft 用の callable AI quality gate を追加する
-  - requirements/design/tasks draft を first-pass AI antipattern review に通し、blocking issue がない場合は fix report なしで完了できる。
-  - fixable issue は current artifact boundary の repair route に戻り、upstream phase 変更や roadmap 再分解が必要な issue は replan/upstream-repair outcome へ分岐する。
-  - ambiguous、blocked、inconsistent outcome が未一致で落ちない catch-all route を持つ。
-  - _Requirements: 3.2, 3.3, 3.4, 3.5, 4.1, 4.2, 4.3, 4.4, 4.5_
-  - _Boundary:_ SpecAiQualityGateWorkflow
+- [x] 2. Discovery-scoped AI quality gate を作る
+- [x] 2.1 discovery artifact 用 callable AI quality gate workflow を追加する
+  - `kiro-discovery-ai-quality-gate` が callable internal subworkflow として en/ja に存在し、first-pass AI antipattern review を最初に実行する。
+  - blocking issue がない場合は fix report なしで `COMPLETE` でき、ambiguous / blocked / internally inconsistent outcome は replan path に流れる。
+  - fixable issue は discovery-scoped fix step に進み、loop exhaustion は `need_replan` を返す。
+  - report names は `kiro-discovery-ai-antipattern-review.md` と `kiro-discovery-ai-antipattern-fix.md` で、implementation/spec generation report names と混ざらない。
+  - _Requirements: 2.7, 3.2, 3.3, 3.4, 3.5, 3.7, 6.2, 6.3, 6.4, 7.7, 8.1, 8.2_
+  - _Boundary:_ DiscoveryAiQualityGateWorkflow
   - _Depends:_ 1.2
 
-- [x] 2.2 generation artifact boundary 用の fix instruction と output contract を追加する
-  - spec artifact boundary 内で直せる内容と、upstream/boundary 外へ返すべき内容が prompt 上で区別される。
-  - generation fix report の machine fields、report names、optional semantics が en/ja で一致している。
-  - implementation progress 用の fix report semantics と混ざらないことが確認できる。
-  - _Requirements: 3.4, 4.4, 4.5, 5.2, 5.3, 8.2, 8.4_
-  - _Boundary:_ SpecAiQualityGateWorkflow, GateEvidenceAdapters
+- [x] 2.2 discovery artifact boundary 用の fix instruction と output contract を追加する
+  - discovery fix instruction が `brief.md` と `.kiro/steering/roadmap.md` の current discovery artifact boundary 内だけを修正対象にする。
+  - requirements/design/tasks artifact、既存 spec ownership、implementation files への越境修正は `NEED_REPLAN` または `BLOCKED` として扱われる。
+  - discovery fix report の machine fields、status values、changed files、scope guard、validation evidence が en/ja で一致する。
+  - first-pass clean の場合に optional fix report 不在が failure にならない semantics が明示される。
+  - _Requirements: 2.7, 3.4, 4.5, 5.2, 5.3, 6.3, 6.4, 7.7, 8.2, 8.4_
+  - _Boundary:_ DiscoveryAiQualityGateWorkflow, GateEvidenceAdapters
   - _Depends:_ 2.1
 
-- [x] 2.3 downstream review/finalize が gate evidence を消費するように facet 指示を更新する
-  - unresolved AI antipattern findings がある draft は domain review/finalize で accept されない。
-  - optional fix report が存在する場合、blocked、stale、cross-run、evidence-free no-fix が reject される。
-  - first-pass no blocking で fix report がない場合は failure にならない。
-  - rejection は既存 repair、replan、blocked route に戻ることが prompt 上で明示される。
-  - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 8.2, 8.4_
-  - _Boundary:_ GateEvidenceAdapters
+- [x] 3. `kiro-discovery` workflow と discovery report evidence を接続する
+- [x] 3.1 `kiro-discovery` の artifact write success path に discovery gate を挿入する
+  - `SINGLE_SPEC`、`MULTI_SPEC`、`MIXED_DECOMPOSITION` の successful write path が `report-discovery` へ直行せず `ai-quality-gate-discovery` へ進む。
+  - `EXISTING_SPEC_UPDATE` と `DIRECT_IMPLEMENTATION` の artifact-less path は discovery gate を bypass して `report-discovery` へ進む。
+  - `ai-quality-gate-discovery` は relative path の `workflow_call` を使い、`COMPLETE` は `report-discovery`、`need_replan` は `plan-discovery-artifacts`、`ABORT` は `ABORT` に進む。
+  - en/ja の workflow structure、step name、call path、routing terms が一致する。
+  - _Requirements: 2.6, 3.1, 3.6, 5.6, 6.2, 6.3, 6.4, 7.6, 8.1_
+  - _Boundary:_ DiscoveryWorkflowIntegration
   - _Depends:_ 2.1, 2.2
 
-- [ ] 3. Eligible generation workflows に gate を接続する
-- [x] 3.1 standalone spec generation workflows に gate route と loop monitor を追加する
-  - requirements、design、tasks の generate/repair 直後に matching gate step が入り、その後に既存 domain review へ進む。
-  - 各 loop monitor cycle に matching gate step が含まれ、finalize から repair へ戻る既存循環も壊れない。
-  - finalize は raw gate report を再評価せず、verified review/finalize result に依存して lifecycle promotion する。
-  - _Requirements: 3.1, 3.6, 4.1, 4.2, 4.3, 4.4, 4.5, 5.5, 8.1_
-  - _Boundary:_ GenerationWorkflowIntegration
-  - _Depends:_ 2.1, 2.3
+- [x] 3.2 `kiro-discovery` caller loop monitor で replan cycle を収束管理する
+  - `plan-discovery-artifacts`、`write-discovery-artifacts`、`ai-quality-gate-discovery` を含む caller loop monitor が en/ja workflow に追加される。
+  - repeated non-convergence が threshold に到達した場合、追加修正を試みず blocked discovery reporting へ進む。
+  - loop monitor が artifact-less path や read-only validation workflows に影響しない。
+  - validator と tests から cycle membership と threshold outcome が観測できる。
+  - _Requirements: 3.5, 3.6, 3.7, 6.4, 7.3, 7.6, 8.1_
+  - _Boundary:_ DiscoveryWorkflowIntegration
+  - _Depends:_ 3.1
 
-- [x] 3.2 quick workflow に phase-local gate route と loop monitor を追加する
-  - quick requirements/design/tasks の各 phase で generate/repair 直後に matching quick gate step が入り、既存 quick review step へ進む。
-  - quick の allowed `workflow_call` は spec AI quality gate だけで、standalone phase workflow reuse は引き続き起きない。
-  - quick の各 phase loop monitor に matching quick gate step が含まれている。
-  - _Requirements: 3.1, 3.6, 4.1, 4.2, 4.3, 4.4, 4.5, 8.1_
-  - _Boundary:_ GenerationWorkflowIntegration
-  - _Depends:_ 2.1, 2.3
+- [x] 3.3 discovery report facet が scoped gate evidence を消費するように更新する
+  - `report-discovery` の指示が namespaced `kiro-discovery-ai-antipattern-review.md` と optional fix report を確認する。
+  - unresolved findings、stale/cross-run/evidence-free no-fix、implementation/spec generation report name の誤用は completion として扱われない。
+  - first-pass no blocking で fix report がない場合は failure にならない。
+  - gate evidence rejection は existing discovery repair/replan/blocked path と整合する。
+  - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.6, 8.2, 8.4_
+  - _Boundary:_ GateEvidenceAdapters
+  - _Depends:_ 3.1
 
-- [x] 3.3 read-only と orchestration の対象外境界を workflow 上で保つ
-  - status/validate workflow に edit-capable gate/fix step、repair/debug step、loop monitor、nested Kiro workflow call が追加されていない。
-  - discovery と batch は artifact-level AI review owner を downstream generation workflows として分類し、直接 fix loop を持たない。
-  - 新規の未判断 orchestration workflow は covered ではなく maintainer decision required として扱える。
-  - _Requirements: 2.2, 2.3, 2.4, 2.5, 6.1, 6.2, 6.3, 6.4_
-  - _Boundary:_ GenerationWorkflowIntegration, ReadOnlyGuardValidator
-  - _Depends:_ 1.1, 3.1, 3.2
-
-- [ ] 4. Validator と unit tests で drift を検出する
-- [x] 4.1 coverage validator を追加して未分類・eligible bypass・不正 gate を検出する
-  - 全 Kiro workflow の分類過不足、eligible generation workflow の gate bypass、判定不能 workflow が actionable finding として fail する。
-  - read-only workflow に gate/fix behavior が入った場合、対象 workflow と violation reason が表示される。
-  - en/ja の workflow structure、call paths、report names、machine routing terms の drift が covered 扱い前に fail する。
-  - _Requirements: 1.1, 1.2, 1.3, 1.4, 7.1, 7.2, 7.5, 8.1, 8.2, 8.5_
+- [x] 4. Validators と unit tests を discovery gate 対応へ更新する
+- [x] 4.1 coverage validator が discovery gate required と forbidden wiring を検出する
+  - `kiro-discovery` に discovery gate call がない場合、actionable failure になる。
+  - `kiro-discovery` に implementation-scoped fix instruction、spec generation report names、または unapproved gate call が配線された場合、具体的な failure になる。
+  - `kiro-discovery-ai-quality-gate` が inventory にない場合、全 workflow exactly once の failure になる。
+  - read-only workflows と `kiro-spec-batch` に direct AI fix loop が入った場合、対象 workflow と violation reason が出力される。
+  - _Requirements: 1.1, 1.2, 1.4, 2.2, 2.4, 2.5, 7.1, 7.2, 7.5, 7.6, 7.7, 8.1, 8.2, 8.5_
   - _Boundary:_ CoverageValidator, ReadOnlyGuardValidator
-  - _Depends:_ 1.1, 1.2, 3.3
+  - _Depends:_ 1.1, 1.2, 3.1, 3.2
 
-- [x] 4.2 existing Kiro validators を shared contract と generation gate placement に合わせて更新する
-  - shared workflow call validator が helper の allowlist を使い、relative gate call 以外の nested Kiro workflow reuse を拒否する。
-  - spec generation validator が standalone/quick の gate placement と quick の限定的 `workflow_call` 許可を検証する。
-  - status/validation validator が coverage helper の read-only list と同期して gate/fix loop 混入を拒否する。
-  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 6.1, 7.2, 7.3_
+- [x] 4.2 discovery/batch と shared validators を allowlist 型の `workflow_call` 検証へ更新する
+  - discovery/batch validator は `kiro-discovery` の approved discovery gate call だけを許可し、phase reuse、shell `takt -w`、`kiro-spec-batch` direct gate を引き続き拒否する。
+  - shared workflow call validator は helper の allowed call sites を正本にし、bare workflow name と unapproved nested Kiro workflow reuse を拒否する。
+  - existing spec generation gate checks は維持され、quick の approved spec gate call だけが許可される。
+  - en/ja parity drift が covered 扱い前に failure になる。
+  - _Requirements: 3.1, 3.2, 3.3, 3.5, 3.6, 6.1, 6.5, 6.6, 7.2, 7.3, 8.1, 8.5_
   - _Boundary:_ SharedGateContractHelper, CoverageValidator, ReadOnlyGuardValidator
   - _Depends:_ 4.1
 
-- [x] 4.3 validator unit tests と parity tests を追加する
-  - positive fixture では implementation gate と generation gate の approved call sites が pass する。
-  - negative fixture では bare workflow name call、quick phase workflow reuse、missing gate、read-only fix loop、language drift が fail する。
-  - policy facet が workflow 別分類表を再掲せず、machine-readable coverage inventory を正本として参照していることを検出できる。
-  - _Requirements: 1.4, 2.4, 2.5, 7.1, 7.2, 7.3, 7.5, 8.1, 8.2, 8.5_
+- [x] 4.3 validator unit tests と parity tests を discovery gate expectations に更新する
+  - positive tests で `kiro-discovery-ai-quality-gate` の `existing_gate_coverage`、`kiro-discovery` の `discovery_artifact_gate_required`、`kiro-spec-batch` の delegated owner が確認される。
+  - negative fixtures で missing discovery gate、wrong fix instruction、wrong report name、unapproved workflow call、read-only fix loop、batch direct gate が fail する。
+  - policy facet が workflow-by-workflow table を複製せず、machine-readable inventory を正本として参照していることが確認される。
+  - 既存 generation-scoped gate の positive/negative tests は、current artifact boundary repair path を含む regression として維持される。
+  - _Requirements: 1.1, 1.3, 1.4, 2.5, 4.1, 4.2, 4.3, 4.4, 5.5, 7.1, 7.2, 7.3, 7.5, 7.6, 7.7, 8.1, 8.2, 8.5_
   - _Boundary:_ CoverageValidator, RuntimeSmokeFixture
   - _Depends:_ 4.2
 
-- [ ] 5. Runtime smoke と repository integration を完了する
-- [x] 5.1 generation-scoped gate の deterministic successful path smoke を追加する
-  - mock provider fixture で spec generation workflow が spec AI gate を通り、no blocking finding の場合に fix report なしで domain review へ進む。
-  - smoke は artifact 品質評価ではなく workflow wiring の検証に限定され、成功時に gate step と後続 review step の到達が観測できる。
-  - runtime smoke が失敗した場合、どの route または report semantics が壊れたかを出力から追える。
-  - _Requirements: 3.4, 4.1, 5.3, 7.4_
+- [x] 5. Runtime smoke と repository integration を完了する
+- [x] 5.1 discovery gate の deterministic successful path smoke を追加する
+  - mock provider fixture で `kiro-discovery` が discovery artifacts を書いた後、discovery gate clean path を通って `report-discovery` に到達する。
+  - smoke は artifact 品質評価ではなく workflow wiring の検証に限定され、gate step と report step の到達が観測できる。
+  - fix report 不在の clean path が failure にならないことが確認される。
+  - 通常実行が Codex provider に切り替わらない opt-in mock path で実行できる。
+  - _Requirements: 3.4, 5.3, 5.6, 6.2, 7.4_
   - _Boundary:_ RuntimeSmokeFixture
-  - _Depends:_ 3.1, 4.2
+  - _Depends:_ 3.1, 3.3, 4.2
 
-- [x] 5.2 npm scripts と CI から新しい validator/test/smoke を実行できるようにする
-  - 新しい validator、unit test、runtime smoke が既存の script naming pattern で実行できる。
-  - CI が Kiro validator/test を個別列挙している場合、新しい checks が同じ段に含まれている。
-  - repository validation を実行すると coverage、shared contract、spec generation、status validation、runtime smoke の対象がすべて検証される。
+- [x] 5.2 repository scripts と CI 対象に discovery gate coverage checks を接続する
+  - 新しいまたは更新された validator、unit test、runtime smoke が既存 npm script naming pattern で実行できる。
+  - CI が Kiro validator/test を個別列挙している場合、discovery gate checks が同じ段に含まれる。
+  - repository validation を実行すると coverage、shared contract、discovery/batch、spec generation、status/read-only、runtime smoke の対象がすべて検証される。
   - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5, 8.1, 8.2, 8.5_
   - _Boundary:_ RuntimeSmokeFixture, CoverageValidator
   - _Depends:_ 4.3, 5.1

--- a/.takt/en/facets/instructions/kiro-ai-antipattern-fix-discovery.md
+++ b/.takt/en/facets/instructions/kiro-ai-antipattern-fix-discovery.md
@@ -1,0 +1,38 @@
+---
+id: kiro-ai-antipattern-fix-discovery
+kind: instruction
+name: Kiro AI Antipattern Fix Discovery
+version: 1.0.0
+Full custom skill reason: TAKT-side reusable AI antipattern gate instruction for Kiro discovery artifacts.
+---
+
+{extends: fix}
+
+# Kiro AI Antipattern Fix Discovery
+
+Fix or adjudicate AI antipattern findings for the current Kiro discovery artifact boundary.
+
+## Inputs
+
+- Read `kiro-discovery-ai-antipattern-review.md` and handle every finding in that report.
+- Use the active discovery output as the authoritative boundary: `.kiro/specs/<feature>/brief.md` and `.kiro/steering/roadmap.md` entries created or updated by the current `kiro-discovery` run.
+- Treat the caller workflow actionPath as authoritative for whether discovery artifacts are expected.
+
+## Scope
+
+- Change only current discovery artifacts: `brief.md` files for newly discovered specs and the matching `.kiro/steering/roadmap.md` decomposition entries.
+- Do not edit requirements.md, design.md, tasks.md, spec.json approval state, implementation files, upstream skills, or existing spec-owned artifacts.
+- Do not update roadmap checkbox markers as implementation progress.
+- Do not start implementation work.
+
+## Fix Rules
+
+- If a finding is valid and fixable inside the current discovery artifact boundary, fix it and report `STATUS: FIXED`.
+- If every finding is inapplicable or already resolved with concrete evidence, report `STATUS: NO_FIX_NEEDED`.
+- If a finding requires changing requirements/design/tasks artifacts, existing spec ownership, implementation files, or upstream Kiro skill behavior, report `STATUS: NEED_REPLAN`.
+- If required context, files, or permissions are unavailable, report `STATUS: BLOCKED`.
+- Preserve finding-level evidence for every decision.
+
+## Output
+
+Write `kiro-discovery-ai-antipattern-fix.md` using the `kiro-discovery-ai-antipattern-fix-result` contract.

--- a/.takt/en/facets/instructions/kiro-discovery.md
+++ b/.takt/en/facets/instructions/kiro-discovery.md
@@ -51,3 +51,12 @@ Keep the brief scoped to the target feature. Do not place existing spec updates 
 - Return `kiro-discovery-result` with `actionPath`, `reason`, `createdFiles`, `plannedFiles`, `nextAction`, `blockingReason`, and `awarenessOnlyItems`.
 - Preserve JSON key, path, script name, and enum spelling exactly.
 - Do not mix OpenSpec artifacts into `.kiro/*` discovery artifact source of truth.
+
+## Discovery AI Gate Evidence
+
+Before `report-discovery` returns completion for `SINGLE_SPEC`, `MULTI_SPEC`, or `MIXED_DECOMPOSITION`, inspect the namespaced subworkflow evidence for the current run:
+
+- `reports/subworkflows/iteration-*--step-ai-quality-gate-discovery--workflow-kiro-discovery-ai-quality-gate/kiro-discovery-ai-antipattern-review.md`
+- optional fix report: `reports/subworkflows/iteration-*--step-ai-quality-gate-discovery--workflow-kiro-discovery-ai-quality-gate/kiro-discovery-ai-antipattern-fix.md`
+
+Treat unresolved findings, stale evidence, cross-run evidence, evidence-free no-fix claims, or implementation/spec generation report names such as `kiro-ai-antipattern-review.md` and `kiro-spec-ai-antipattern-review.md` as not complete. Missing `kiro-discovery-ai-antipattern-fix.md` is acceptable only when the first-pass `kiro-discovery-ai-antipattern-review.md` reports no blocking findings.

--- a/.takt/en/facets/output-contracts/kiro-discovery-ai-antipattern-fix-result.md
+++ b/.takt/en/facets/output-contracts/kiro-discovery-ai-antipattern-fix-result.md
@@ -1,0 +1,33 @@
+---
+id: kiro-discovery-ai-antipattern-fix-result
+kind: output-contract
+name: Kiro Discovery AI Antipattern Fix Result
+version: 1.0.0
+extends: validation
+---
+
+{extends: validation}
+
+# Kiro Discovery AI Antipattern Fix Result
+
+Report the result of fixing AI antipattern findings for Kiro discovery artifacts before `report-discovery` runs.
+
+## Required Machine Fields
+
+- `STATUS`: one of `FIXED`, `NO_FIX_NEEDED`, `NEED_REPLAN`, or `BLOCKED`.
+- `finding_decisions`: list each finding from `kiro-discovery-ai-antipattern-review.md` and mark it as fixed, not applicable, requires replan, or blocked.
+- `changed_files`: discovery artifact files changed by this fix pass, or `none`.
+- `scope_guard`: confirmation that the pass only touched the current discovery artifact boundary.
+- `validation_evidence`: checks, commands, or file-level evidence used to support the status.
+- `no_fix_rationale`: required when `STATUS` is `NO_FIX_NEEDED`; include finding-level evidence.
+- `missing_context`: required when `STATUS` is `NEED_REPLAN` or `BLOCKED`.
+- `summary`: concise human-readable result.
+
+## Status Semantics
+
+- `FIXED`: at least one finding was corrected and the gate must run the AI antipattern review again.
+- `NO_FIX_NEEDED`: every finding is shown to be inapplicable or already resolved with concrete evidence.
+- `NEED_REPLAN`: the issue cannot be fixed safely within the current discovery artifact boundary.
+- `BLOCKED`: required information, files, or permissions are unavailable.
+
+The report filename must be `kiro-discovery-ai-antipattern-fix.md`. The report is an `optional fix report` when the first-pass `kiro-discovery-ai-antipattern-review.md` has no blocking findings.

--- a/.takt/en/facets/policies/kiro-ai-quality-gate-coverage.md
+++ b/.takt/en/facets/policies/kiro-ai-quality-gate-coverage.md
@@ -11,6 +11,7 @@ Full custom reason: upstream Kiro skills do not define TAKT-specific AI quality 
 ## Category Semantics
 
 - `existing_gate_coverage`: the workflow already owns or calls an approved AI quality gate.
+- `discovery_artifact_gate_required`: the workflow writes discovery artifacts that proceed to discovery reporting and must pass a discovery-scoped AI quality gate.
 - `generation_scoped_gate_required`: the workflow generates or repairs spec artifacts that proceed to domain review or lifecycle promotion.
 - `orchestration_decision_required`: the workflow writes planning or coordination artifacts and needs an explicit maintainer decision before any AI review or fix loop is added.
 - `orchestration_delegated`: artifact-level AI quality review belongs to adjacent generation workflows rather than the orchestration workflow itself.
@@ -22,6 +23,6 @@ Full custom reason: upstream Kiro skills do not define TAKT-specific AI quality 
 
 - Add an AI quality gate only where generated or repaired artifacts proceed to domain-specific review or finalization.
 - Keep read-only workflows read-only. Do not add repair, debug, edit, or nested workflow behavior to make coverage look complete.
-- Treat orchestration workflows as explicit design decisions, not automatic gate targets.
+- Treat orchestration workflows as explicit design decisions, not automatic gate targets. Discovery artifact gates are allowed only when listed in `scripts/kiro-ai-quality-gate-contracts.mjs`.
 - A `roadmap checkbox` marks spec generation state only. It is not implementation progress evidence and must not drive coverage classification.
 - If a new Kiro workflow cannot be classified from its artifact boundary and operator-visible responsibility, return `maintainer_decision_required`.

--- a/.takt/en/workflows/kiro-discovery-ai-quality-gate.yaml
+++ b/.takt/en/workflows/kiro-discovery-ai-quality-gate.yaml
@@ -1,0 +1,132 @@
+name: kiro-discovery-ai-quality-gate
+description: Kiro - callable AI antipattern quality gate for discovery artifacts
+subworkflow:
+  callable: true
+  visibility: internal
+  returns:
+    - need_replan
+  params:
+    fix_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: kiro-ai-antipattern-fix-discovery
+    domain_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default:
+        - architecture
+workflow_config:
+  provider_options:
+    codex:
+      network_access: true
+    opencode:
+      network_access: true
+max_steps: 12
+initial_step: ai-antipattern-review-1st
+
+instructions:
+  kiro-ai-antipattern-fix-discovery: ../facets/instructions/kiro-ai-antipattern-fix-discovery.md
+
+policies:
+  kiro-artifact-operations: ../facets/policies/kiro-artifact-operations.md
+  kiro-discovery-routing: ../facets/policies/kiro-discovery-routing.md
+
+report_formats:
+  kiro-discovery-ai-antipattern-fix-result: ../facets/output-contracts/kiro-discovery-ai-antipattern-fix-result.md
+
+loop_monitors:
+  - cycle:
+      - ai-antipattern-review-1st
+      - ai-antipattern-fix
+    threshold: 3
+    judge:
+      persona: supervisor
+      instruction: loop-monitor-ai-antipattern-fix
+      rules:
+        - condition: Healthy (findings are shrinking or the latest fix has concrete finding_decisions)
+          next: ai-antipattern-review-1st
+        - condition: Unproductive (loop_monitors.threshold reached for ai-antipattern-review-1st and ai-antipattern-fix)
+          next: request-replan
+
+steps:
+  - name: ai-antipattern-review-1st
+    edit: false
+    persona: ai-antipattern-reviewer
+    policy:
+      - review
+      - ai-antipattern
+      - kiro-artifact-operations
+      - kiro-discovery-routing
+    knowledge:
+      $param: domain_knowledge
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Bash
+    required_permission_mode: readonly
+    instruction: ai-antipattern-review
+    output_contracts:
+      report:
+        - name: kiro-discovery-ai-antipattern-review.md
+          format: ai-antipattern-review
+    rules:
+      - condition: No AI-specific issues
+        next: COMPLETE
+      - condition: AI-specific issues found
+        next: ai-antipattern-fix
+      - when: "true"
+        next: request-replan
+        appendix: Treat ambiguous, blocked, or internally inconsistent review outcomes as requiring replanning.
+
+  - name: ai-antipattern-fix
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+      - ai-antipattern
+      - kiro-artifact-operations
+      - kiro-discovery-routing
+    session: refresh
+    knowledge:
+      $param: domain_knowledge
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+    required_permission_mode: edit
+    pass_previous_response: false
+    instruction:
+      $param: fix_instruction
+    output_contracts:
+      report:
+        - name: kiro-discovery-ai-antipattern-fix.md
+          format: kiro-discovery-ai-antipattern-fix-result
+    rules:
+      - condition: STATUS FIXED
+        next: ai-antipattern-review-1st
+      - condition: STATUS NO_FIX_NEEDED and finding-level evidence supports every finding_decision
+        next: COMPLETE
+      - condition: STATUS NEED_REPLAN
+        return: need_replan
+      - condition: STATUS BLOCKED
+        next: request-replan
+
+  - name: request-replan
+    edit: false
+    persona: supervisor
+    required_permission_mode: readonly
+    instruction: |
+      The discovery AI antipattern quality gate requires replanning because the review outcome was ambiguous, blocked, internally inconsistent, or the review/fix loop did not converge.
+      Return need_replan so the caller workflow can route back to discovery artifact planning instead of reporting completion.
+    rules:
+      - condition: Replan is required after an ambiguous, blocked, or internally inconsistent AI antipattern review outcome or an unproductive AI antipattern fix loop
+        return: need_replan

--- a/.takt/en/workflows/kiro-discovery.yaml
+++ b/.takt/en/workflows/kiro-discovery.yaml
@@ -6,11 +6,12 @@ workflow_config:
       network_access: true
     opencode:
       network_access: true
-max_steps: 8
+max_steps: 12
 initial_step: classify-action-path
 
 instructions:
   kiro-discovery: ../facets/instructions/kiro-discovery.md
+  kiro-ai-antipattern-fix-discovery: ../facets/instructions/kiro-ai-antipattern-fix-discovery.md
 
 policies:
   kiro-artifact-operations: ../facets/policies/kiro-artifact-operations.md
@@ -18,6 +19,21 @@ policies:
 
 report_formats:
   kiro-discovery-result: ../facets/output-contracts/kiro-discovery-result.md
+
+loop_monitors:
+  - cycle:
+      - plan-discovery-artifacts
+      - write-discovery-artifacts
+      - ai-quality-gate-discovery
+    threshold: 2
+    judge:
+      persona: supervisor
+      instruction: kiro-discovery
+      rules:
+        - condition: Healthy (discovery artifacts are converging and loop_monitors.threshold not reached)
+          next: plan-discovery-artifacts
+        - condition: Unproductive (loop_monitors.threshold reached for plan-discovery-artifacts, write-discovery-artifacts, and ai-quality-gate-discovery)
+          next: report-discovery
 
 steps:
   - name: classify-action-path
@@ -68,13 +84,28 @@ steps:
       - condition: artifact write failed or blockingReason present
         next: report-discovery
       - condition: createdFiles include target brief.md and actionPath SINGLE_SPEC
-        next: report-discovery
+        next: ai-quality-gate-discovery
       - condition: createdFiles include every new spec brief.md and .kiro/steering/roadmap.md and actionPath MULTI_SPEC
-        next: report-discovery
+        next: ai-quality-gate-discovery
       - condition: createdFiles include every new spec brief.md and .kiro/steering/roadmap.md and awarenessOnlyItems non-empty and separated and actionPath MIXED_DECOMPOSITION
-        next: report-discovery
+        next: ai-quality-gate-discovery
       - condition: required createdFiles missing for actionPath SINGLE_SPEC or actionPath MULTI_SPEC or actionPath MIXED_DECOMPOSITION
         next: report-discovery
+
+  - name: ai-quality-gate-discovery
+    kind: workflow_call
+    call: ./kiro-discovery-ai-quality-gate.yaml
+    args:
+      fix_instruction: kiro-ai-antipattern-fix-discovery
+      domain_knowledge:
+        - architecture
+    rules:
+      - condition: COMPLETE
+        next: report-discovery
+      - condition: need_replan
+        next: plan-discovery-artifacts
+      - condition: ABORT
+        next: ABORT
 
   - name: report-discovery
     edit: false
@@ -89,13 +120,13 @@ steps:
         - name: kiro-discovery-result.md
           format: kiro-discovery-result
     rules:
-      - condition: blockingReason present or artifact write failed or brief.md roadmap contradiction found or required discovery artifacts missing
+      - condition: blockingReason present or artifact write failed or brief.md roadmap contradiction found or required discovery artifacts missing or discovery AI quality gate blocked or loop_monitors.threshold reached
         next: ABORT
       - condition: actionPath EXISTING_SPEC_UPDATE or actionPath DIRECT_IMPLEMENTATION
         next: COMPLETE
-      - condition: actionPath SINGLE_SPEC and target brief.md present
+      - condition: actionPath SINGLE_SPEC and target brief.md present and discovery AI quality gate passed
         next: COMPLETE
-      - condition: actionPath MULTI_SPEC and every new spec brief.md present and .kiro/steering/roadmap.md present
+      - condition: actionPath MULTI_SPEC and every new spec brief.md present and .kiro/steering/roadmap.md present and discovery AI quality gate passed
         next: COMPLETE
-      - condition: actionPath MIXED_DECOMPOSITION and every new spec brief.md present and .kiro/steering/roadmap.md present and awarenessOnlyItems non-empty and separated
+      - condition: actionPath MIXED_DECOMPOSITION and every new spec brief.md present and .kiro/steering/roadmap.md present and awarenessOnlyItems non-empty and separated and discovery AI quality gate passed
         next: COMPLETE

--- a/.takt/ja/facets/instructions/kiro-ai-antipattern-fix-discovery.md
+++ b/.takt/ja/facets/instructions/kiro-ai-antipattern-fix-discovery.md
@@ -1,0 +1,38 @@
+---
+id: kiro-ai-antipattern-fix-discovery
+kind: instruction
+name: Kiro AI Antipattern Fix Discovery
+version: 1.0.0
+Full custom skill reason: TAKT-side reusable AI antipattern gate instruction for Kiro discovery artifacts.
+---
+
+{extends: fix}
+
+# Kiro AI Antipattern Fix Discovery
+
+current Kiro discovery artifact boundary に対する AI antipattern finding を修正または裁定する。
+
+## Inputs
+
+- `kiro-discovery-ai-antipattern-review.md` を読み、その report のすべての finding を扱う。
+- current `kiro-discovery` run が作成または更新した `.kiro/specs/<feature>/brief.md` と `.kiro/steering/roadmap.md` entries を authoritative boundary とする。
+- caller workflow の actionPath を、discovery artifact が必要かどうかの正本として扱う。
+
+## Scope
+
+- 修正対象は current discovery artifacts のみ: newly discovered specs の `brief.md` と対応する `.kiro/steering/roadmap.md` decomposition entries。
+- requirements.md、design.md、tasks.md、spec.json approval state、implementation files、upstream skills、existing spec-owned artifacts は編集しない。
+- roadmap checkbox markers を implementation progress として更新しない。
+- implementation work を開始しない。
+
+## Fix Rules
+
+- finding が妥当で current discovery artifact boundary 内で修正可能なら修正し、`STATUS: FIXED` を報告する。
+- すべての finding が不適用または concrete evidence により既に解消済みなら、`STATUS: NO_FIX_NEEDED` を報告する。
+- finding が requirements/design/tasks artifacts、existing spec ownership、implementation files、upstream Kiro skill behavior の変更を必要とする場合は、`STATUS: NEED_REPLAN` を報告する。
+- 必要な context、files、permissions が利用できない場合は、`STATUS: BLOCKED` を報告する。
+- すべての decision に finding-level evidence を残す。
+
+## Output
+
+`kiro-discovery-ai-antipattern-fix-result` contract に従って `kiro-discovery-ai-antipattern-fix.md` を書く。

--- a/.takt/ja/facets/instructions/kiro-discovery.md
+++ b/.takt/ja/facets/instructions/kiro-discovery.md
@@ -51,3 +51,12 @@ brief は対象 feature に閉じる。既存 spec 更新や direct implementati
 - `actionPath`、`reason`、`createdFiles`、`plannedFiles`、`nextAction`、`blockingReason`、`awarenessOnlyItems` を含む `kiro-discovery-result` を返す。
 - JSON key、path、script name、enum spelling は正確に維持する。
 - OpenSpec artifacts を `.kiro/*` discovery artifact の source of truth に混ぜない。
+
+## Discovery AI Gate Evidence
+
+`report-discovery` が `SINGLE_SPEC`、`MULTI_SPEC`、`MIXED_DECOMPOSITION` の completion を返す前に、current run の namespaced subworkflow evidence を確認する:
+
+- `reports/subworkflows/iteration-*--step-ai-quality-gate-discovery--workflow-kiro-discovery-ai-quality-gate/kiro-discovery-ai-antipattern-review.md`
+- optional fix report: `reports/subworkflows/iteration-*--step-ai-quality-gate-discovery--workflow-kiro-discovery-ai-quality-gate/kiro-discovery-ai-antipattern-fix.md`
+
+unresolved findings、stale evidence、cross-run evidence、evidence-free no-fix claims、または `kiro-ai-antipattern-review.md` や `kiro-spec-ai-antipattern-review.md` のような implementation/spec generation report names は complete と扱わない。first-pass `kiro-discovery-ai-antipattern-review.md` に blocking findings がない場合だけ、`kiro-discovery-ai-antipattern-fix.md` が missing でも許容する。

--- a/.takt/ja/facets/output-contracts/kiro-discovery-ai-antipattern-fix-result.md
+++ b/.takt/ja/facets/output-contracts/kiro-discovery-ai-antipattern-fix-result.md
@@ -1,0 +1,33 @@
+---
+id: kiro-discovery-ai-antipattern-fix-result
+kind: output-contract
+name: Kiro Discovery AI Antipattern Fix Result
+version: 1.0.0
+extends: validation
+---
+
+{extends: validation}
+
+# Kiro Discovery AI Antipattern Fix Result
+
+`report-discovery` が実行される前に、Kiro discovery artifacts の AI antipattern findings を修正した結果を報告する。
+
+## Required Machine Fields
+
+- `STATUS`: `FIXED`、`NO_FIX_NEEDED`、`NEED_REPLAN`、`BLOCKED` のいずれか。
+- `finding_decisions`: `kiro-discovery-ai-antipattern-review.md` の各 finding を列挙し、fixed、not applicable、requires replan、blocked のいずれかで示す。
+- `changed_files`: この fix pass で変更した discovery artifact files、または `none`。
+- `scope_guard`: current discovery artifact boundary のみを触った確認。
+- `validation_evidence`: status を裏付ける checks、commands、file-level evidence。
+- `no_fix_rationale`: `STATUS` が `NO_FIX_NEEDED` の場合に必須。finding-level evidence を含める。
+- `missing_context`: `STATUS` が `NEED_REPLAN` または `BLOCKED` の場合に必須。
+- `summary`: concise human-readable result。
+
+## Status Semantics
+
+- `FIXED`: 少なくとも 1 件の finding を修正した。gate は AI antipattern review を再実行する。
+- `NO_FIX_NEEDED`: すべての finding が不適用または concrete evidence により既に解消済みである。
+- `NEED_REPLAN`: current discovery artifact boundary 内では安全に修正できない。
+- `BLOCKED`: 必要な information、files、permissions が利用できない。
+
+report filename は `kiro-discovery-ai-antipattern-fix.md` でなければならない。first-pass `kiro-discovery-ai-antipattern-review.md` に blocking findings がない場合、この report は optional fix report として不在でもよい。

--- a/.takt/ja/facets/policies/kiro-ai-quality-gate-coverage.md
+++ b/.takt/ja/facets/policies/kiro-ai-quality-gate-coverage.md
@@ -11,6 +11,7 @@ Full custom reason: upstream Kiro skills do not define TAKT-specific AI quality 
 ## Category Semantics
 
 - `existing_gate_coverage`: workflow が承認済み AI quality gate をすでに所有または呼び出している。
+- `discovery_artifact_gate_required`: workflow が discovery reporting へ進む discovery artifacts を書くため、discovery-scoped AI quality gate を通す必要がある。
 - `generation_scoped_gate_required`: workflow が domain review または lifecycle promotion へ進む spec artifact を生成または修正する。
 - `orchestration_decision_required`: workflow が planning / coordination artifact を書くため、AI review / fix loop 追加前に maintainer decision が必要である。
 - `orchestration_delegated`: artifact-level AI quality review は orchestration workflow ではなく隣接する generation workflow が所有する。
@@ -22,6 +23,6 @@ Full custom reason: upstream Kiro skills do not define TAKT-specific AI quality 
 
 - generated / repaired artifact が domain-specific review または finalization へ進む場合だけ AI quality gate を追加する。
 - read-only workflow は read-only のまま保つ。coverage を満たすために repair、debug、edit、nested workflow behavior を追加しない。
-- orchestration workflow は automatic gate target ではなく explicit design decision として扱う。
+- orchestration workflow は automatic gate target ではなく explicit design decision として扱う。Discovery artifact gate は `scripts/kiro-ai-quality-gate-contracts.mjs` に列挙されている場合だけ許可する。
 - `roadmap checkbox` は spec generation state を示すだけである。implementation progress evidence ではなく、coverage classification を駆動してはならない。
 - 新しい Kiro workflow が artifact boundary と operator-visible responsibility から分類できない場合は `maintainer_decision_required` を返す。

--- a/.takt/ja/workflows/kiro-discovery-ai-quality-gate.yaml
+++ b/.takt/ja/workflows/kiro-discovery-ai-quality-gate.yaml
@@ -1,0 +1,132 @@
+name: kiro-discovery-ai-quality-gate
+description: Kiro - discovery artifact 向けの callable AI antipattern quality gate
+subworkflow:
+  callable: true
+  visibility: internal
+  returns:
+    - need_replan
+  params:
+    fix_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: kiro-ai-antipattern-fix-discovery
+    domain_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default:
+        - architecture
+workflow_config:
+  provider_options:
+    codex:
+      network_access: true
+    opencode:
+      network_access: true
+max_steps: 12
+initial_step: ai-antipattern-review-1st
+
+instructions:
+  kiro-ai-antipattern-fix-discovery: ../facets/instructions/kiro-ai-antipattern-fix-discovery.md
+
+policies:
+  kiro-artifact-operations: ../facets/policies/kiro-artifact-operations.md
+  kiro-discovery-routing: ../facets/policies/kiro-discovery-routing.md
+
+report_formats:
+  kiro-discovery-ai-antipattern-fix-result: ../facets/output-contracts/kiro-discovery-ai-antipattern-fix-result.md
+
+loop_monitors:
+  - cycle:
+      - ai-antipattern-review-1st
+      - ai-antipattern-fix
+    threshold: 3
+    judge:
+      persona: supervisor
+      instruction: loop-monitor-ai-antipattern-fix
+      rules:
+        - condition: Healthy (findings are shrinking or the latest fix has concrete finding_decisions)
+          next: ai-antipattern-review-1st
+        - condition: Unproductive (loop_monitors.threshold reached for ai-antipattern-review-1st and ai-antipattern-fix)
+          next: request-replan
+
+steps:
+  - name: ai-antipattern-review-1st
+    edit: false
+    persona: ai-antipattern-reviewer
+    policy:
+      - review
+      - ai-antipattern
+      - kiro-artifact-operations
+      - kiro-discovery-routing
+    knowledge:
+      $param: domain_knowledge
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Bash
+    required_permission_mode: readonly
+    instruction: ai-antipattern-review
+    output_contracts:
+      report:
+        - name: kiro-discovery-ai-antipattern-review.md
+          format: ai-antipattern-review
+    rules:
+      - condition: No AI-specific issues
+        next: COMPLETE
+      - condition: AI-specific issues found
+        next: ai-antipattern-fix
+      - when: "true"
+        next: request-replan
+        appendix: Treat ambiguous, blocked, or internally inconsistent review outcomes as requiring replanning.
+
+  - name: ai-antipattern-fix
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+      - ai-antipattern
+      - kiro-artifact-operations
+      - kiro-discovery-routing
+    session: refresh
+    knowledge:
+      $param: domain_knowledge
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+    required_permission_mode: edit
+    pass_previous_response: false
+    instruction:
+      $param: fix_instruction
+    output_contracts:
+      report:
+        - name: kiro-discovery-ai-antipattern-fix.md
+          format: kiro-discovery-ai-antipattern-fix-result
+    rules:
+      - condition: STATUS FIXED
+        next: ai-antipattern-review-1st
+      - condition: STATUS NO_FIX_NEEDED and finding-level evidence supports every finding_decision
+        next: COMPLETE
+      - condition: STATUS NEED_REPLAN
+        return: need_replan
+      - condition: STATUS BLOCKED
+        next: request-replan
+
+  - name: request-replan
+    edit: false
+    persona: supervisor
+    required_permission_mode: readonly
+    instruction: |
+      discovery AI antipattern quality gate で、review outcome が ambiguous、blocked、internally inconsistent、または review/fix loop が収束しないため replan が必要。
+      caller workflow が completion reporting に進まず、discovery artifact planning へ戻れるように need_replan を返す。
+    rules:
+      - condition: Replan is required after an ambiguous, blocked, or internally inconsistent AI antipattern review outcome or an unproductive AI antipattern fix loop
+        return: need_replan

--- a/.takt/ja/workflows/kiro-discovery.yaml
+++ b/.takt/ja/workflows/kiro-discovery.yaml
@@ -6,11 +6,12 @@ workflow_config:
       network_access: true
     opencode:
       network_access: true
-max_steps: 8
+max_steps: 12
 initial_step: classify-action-path
 
 instructions:
   kiro-discovery: ../facets/instructions/kiro-discovery.md
+  kiro-ai-antipattern-fix-discovery: ../facets/instructions/kiro-ai-antipattern-fix-discovery.md
 
 policies:
   kiro-artifact-operations: ../facets/policies/kiro-artifact-operations.md
@@ -18,6 +19,21 @@ policies:
 
 report_formats:
   kiro-discovery-result: ../facets/output-contracts/kiro-discovery-result.md
+
+loop_monitors:
+  - cycle:
+      - plan-discovery-artifacts
+      - write-discovery-artifacts
+      - ai-quality-gate-discovery
+    threshold: 2
+    judge:
+      persona: supervisor
+      instruction: kiro-discovery
+      rules:
+        - condition: Healthy (discovery artifacts are converging and loop_monitors.threshold not reached)
+          next: plan-discovery-artifacts
+        - condition: Unproductive (loop_monitors.threshold reached for plan-discovery-artifacts, write-discovery-artifacts, and ai-quality-gate-discovery)
+          next: report-discovery
 
 steps:
   - name: classify-action-path
@@ -68,13 +84,28 @@ steps:
       - condition: artifact write failed or blockingReason present
         next: report-discovery
       - condition: createdFiles include target brief.md and actionPath SINGLE_SPEC
-        next: report-discovery
+        next: ai-quality-gate-discovery
       - condition: createdFiles include every new spec brief.md and .kiro/steering/roadmap.md and actionPath MULTI_SPEC
-        next: report-discovery
+        next: ai-quality-gate-discovery
       - condition: createdFiles include every new spec brief.md and .kiro/steering/roadmap.md and awarenessOnlyItems non-empty and separated and actionPath MIXED_DECOMPOSITION
-        next: report-discovery
+        next: ai-quality-gate-discovery
       - condition: required createdFiles missing for actionPath SINGLE_SPEC or actionPath MULTI_SPEC or actionPath MIXED_DECOMPOSITION
         next: report-discovery
+
+  - name: ai-quality-gate-discovery
+    kind: workflow_call
+    call: ./kiro-discovery-ai-quality-gate.yaml
+    args:
+      fix_instruction: kiro-ai-antipattern-fix-discovery
+      domain_knowledge:
+        - architecture
+    rules:
+      - condition: COMPLETE
+        next: report-discovery
+      - condition: need_replan
+        next: plan-discovery-artifacts
+      - condition: ABORT
+        next: ABORT
 
   - name: report-discovery
     edit: false
@@ -89,13 +120,13 @@ steps:
         - name: kiro-discovery-result.md
           format: kiro-discovery-result
     rules:
-      - condition: blockingReason present or artifact write failed or brief.md roadmap contradiction found or required discovery artifacts missing
+      - condition: blockingReason present or artifact write failed or brief.md roadmap contradiction found or required discovery artifacts missing or discovery AI quality gate blocked or loop_monitors.threshold reached
         next: ABORT
       - condition: actionPath EXISTING_SPEC_UPDATE or actionPath DIRECT_IMPLEMENTATION
         next: COMPLETE
-      - condition: actionPath SINGLE_SPEC and target brief.md present
+      - condition: actionPath SINGLE_SPEC and target brief.md present and discovery AI quality gate passed
         next: COMPLETE
-      - condition: actionPath MULTI_SPEC and every new spec brief.md present and .kiro/steering/roadmap.md present
+      - condition: actionPath MULTI_SPEC and every new spec brief.md present and .kiro/steering/roadmap.md present and discovery AI quality gate passed
         next: COMPLETE
-      - condition: actionPath MIXED_DECOMPOSITION and every new spec brief.md present and .kiro/steering/roadmap.md present and awarenessOnlyItems non-empty and separated
+      - condition: actionPath MIXED_DECOMPOSITION and every new spec brief.md present and .kiro/steering/roadmap.md present and awarenessOnlyItems non-empty and separated and discovery AI quality gate passed
         next: COMPLETE

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "validate:kiro-iterative-implementation-workflow": "node scripts/validate-kiro-iterative-implementation-workflow.mjs",
     "test:kiro-iterative-implementation-workflow": "node --test tests/kiro-iterative-implementation-workflow.test.mjs",
     "test:kiro-ai-quality-gate-runtime-smoke": "node --test tests/kiro-ai-quality-gate-runtime-smoke.test.mjs",
+    "test:kiro-discovery-ai-quality-gate-runtime-smoke": "node --test --test-name-pattern \"kiro discovery runtime wiring\" tests/kiro-ai-quality-gate-runtime-smoke.test.mjs",
     "cc-sdd:full": "scripts/takt.sh --pipeline --skip-git -w cc-sdd-full -t",
     "cc-sdd:requirements": "scripts/takt.sh --pipeline --skip-git -w cc-sdd-requirements -t",
     "cc-sdd:validate-gap": "scripts/takt.sh --pipeline --skip-git -w cc-sdd-validate-gap -t",

--- a/scripts/kiro-ai-quality-gate-contracts.mjs
+++ b/scripts/kiro-ai-quality-gate-contracts.mjs
@@ -1,5 +1,6 @@
 export const kiroWorkflowCoverageCategories = Object.freeze([
   "existing_gate_coverage",
+  "discovery_artifact_gate_required",
   "generation_scoped_gate_required",
   "orchestration_decision_required",
   "orchestration_delegated",
@@ -18,6 +19,11 @@ const coverageEntries = Object.freeze([
     workflowName: "kiro-spec-ai-quality-gate",
     category: "existing_gate_coverage",
     reason: "Callable spec generation AI quality gate owns AI antipattern review and fix behavior for generated drafts.",
+  },
+  {
+    workflowName: "kiro-discovery-ai-quality-gate",
+    category: "existing_gate_coverage",
+    reason: "Callable discovery artifact AI quality gate owns AI antipattern review and fix behavior for discovery drafts.",
   },
   {
     workflowName: "kiro-impl",
@@ -57,9 +63,9 @@ const coverageEntries = Object.freeze([
   },
   {
     workflowName: "kiro-discovery",
-    category: "orchestration_delegated",
-    reason: "Discovery writes planning inputs, while downstream spec generation workflows own artifact-level AI review.",
-    adjacentOwner: "kiro-spec-init, kiro-spec-requirements",
+    category: "discovery_artifact_gate_required",
+    reason: "Discovery writes brief and roadmap planning artifacts that must pass a discovery-scoped AI gate before reporting completion.",
+    allowedGateCall: "./kiro-discovery-ai-quality-gate.yaml",
   },
   {
     workflowName: "kiro-spec-batch",
@@ -95,6 +101,12 @@ const allowedGateCallSites = Object.freeze([
     stepName: "ai-quality-gate",
     callPath: "./kiro-ai-quality-gate.yaml",
     gateKind: "implementation",
+  },
+  {
+    workflowName: "kiro-discovery",
+    stepName: "ai-quality-gate-discovery",
+    callPath: "./kiro-discovery-ai-quality-gate.yaml",
+    gateKind: "discovery_artifact",
   },
   {
     workflowName: "kiro-spec-requirements",
@@ -143,10 +155,15 @@ const gateContractTerms = Object.freeze({
     reviewReports: Object.freeze(["kiro-spec-ai-antipattern-review.md"]),
     optionalFixReports: Object.freeze(["kiro-spec-ai-antipattern-fix.md"]),
   }),
+  discoveryArtifact: Object.freeze({
+    reviewReports: Object.freeze(["kiro-discovery-ai-antipattern-review.md"]),
+    optionalFixReports: Object.freeze(["kiro-discovery-ai-antipattern-fix.md"]),
+  }),
   shared: Object.freeze({
     routingTerms: Object.freeze(["No AI-specific issues", "AI-specific issues found"]),
     catchAllTerms: Object.freeze(["ambiguous", "blocked", "internally inconsistent"]),
     loopOutcomeTerms: Object.freeze(["need_replan", "replan"]),
+    callTerms: Object.freeze(["callable: true", "visibility: internal"]),
   }),
 });
 
@@ -179,10 +196,15 @@ export function getKiroAiQualityGateContractTerms() {
       reviewReports: [...gateContractTerms.specGeneration.reviewReports],
       optionalFixReports: [...gateContractTerms.specGeneration.optionalFixReports],
     },
+    discoveryArtifact: {
+      reviewReports: [...gateContractTerms.discoveryArtifact.reviewReports],
+      optionalFixReports: [...gateContractTerms.discoveryArtifact.optionalFixReports],
+    },
     shared: {
       routingTerms: [...gateContractTerms.shared.routingTerms],
       catchAllTerms: [...gateContractTerms.shared.catchAllTerms],
       loopOutcomeTerms: [...gateContractTerms.shared.loopOutcomeTerms],
+      callTerms: [...gateContractTerms.shared.callTerms],
     },
   };
 }

--- a/scripts/validate-kiro-ai-quality-gate-workflow-coverage.mjs
+++ b/scripts/validate-kiro-ai-quality-gate-workflow-coverage.mjs
@@ -12,7 +12,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const defaultRepoRoot = join(__dirname, "..");
 const languages = ["en", "ja"];
-const generationGateRequiredCategories = new Set(["existing_gate_coverage", "generation_scoped_gate_required"]);
+const gateRequiredCategories = new Set([
+  "existing_gate_coverage",
+  "discovery_artifact_gate_required",
+  "generation_scoped_gate_required",
+]);
 const noDirectGateCategories = new Set(["orchestration_delegated", "orchestration_decision_required"]);
 const decisionRequiredCategories = new Set(["maintainer_decision_required", "orchestration_decision_required"]);
 
@@ -161,7 +165,7 @@ function validateGatePlacement(repoRoot, coverageEntries) {
   const entries = coverageEntries;
   const allowedSites = getAllowedKiroAiQualityGateCallSites();
 
-  for (const entry of entries.filter((candidate) => generationGateRequiredCategories.has(candidate.category))) {
+  for (const entry of entries.filter((candidate) => gateRequiredCategories.has(candidate.category))) {
     const sites = allowedSites.filter((site) => site.workflowName === entry.workflowName);
     if (entry.allowedGateCall && sites.length === 0) {
       failures.push(`ELIGIBLE_GATE_BYPASS: ${entry.workflowName} requires ${entry.allowedGateCall} but has no allowed call sites`);
@@ -194,6 +198,35 @@ function validateGatePlacement(repoRoot, coverageEntries) {
           if (!content.includes(`condition: Healthy (review findings are converging)\n          next: ${site.stepName}`)) {
             failures.push(
               `LOOP_MONITOR_GATE_BYPASS: ${rel(repoRoot, path)} loop monitor Healthy branch must route to ${site.stepName} before domain review`,
+            );
+          }
+        }
+        if (site.gateKind === "discovery_artifact") {
+          const gateBlock = stepBlocks(content).find((block) => stepScalar(block, "name") === site.stepName) ?? [];
+          if (ruleNextForCondition(gateBlock, "need_replan") !== "plan-discovery-artifacts") {
+            failures.push(
+              `REPLAN_ROUTING_DRIFT: ${rel(repoRoot, path)} ${site.stepName} must route need_replan to plan-discovery-artifacts`,
+            );
+          }
+          if (ruleNextForCondition(gateBlock, "COMPLETE") !== "report-discovery") {
+            failures.push(
+              `ELIGIBLE_GATE_BYPASS: ${rel(repoRoot, path)} ${site.stepName} COMPLETE must route to report-discovery`,
+            );
+          }
+          for (const term of [
+            "loop_monitors:",
+            "- plan-discovery-artifacts",
+            "- write-discovery-artifacts",
+            "- ai-quality-gate-discovery",
+            "loop_monitors.threshold reached for plan-discovery-artifacts, write-discovery-artifacts, and ai-quality-gate-discovery",
+          ]) {
+            if (!content.includes(term)) {
+              failures.push(`LOOP_MONITOR_GATE_BYPASS: ${rel(repoRoot, path)} missing discovery gate loop term: ${term}`);
+            }
+          }
+          if (content.includes("kiro-ai-antipattern-fix-implementation") || content.includes("kiro-spec-ai-antipattern-review.md")) {
+            failures.push(
+              `DISCOVERY_GATE_SCOPE_DRIFT: ${rel(repoRoot, path)} must use discovery-scoped fix instruction and report names`,
             );
           }
         }
@@ -256,23 +289,74 @@ function validateReadOnlyAndDelegatedBoundaries(repoRoot, coverageEntries) {
 function validateGateContractTerms(repoRoot) {
   const failures = [];
   const terms = getKiroAiQualityGateContractTerms();
-  const specTerms = [
-    ...terms.specGeneration.reviewReports,
-    ...terms.specGeneration.optionalFixReports,
-    ...terms.shared.routingTerms,
-    ...terms.shared.catchAllTerms,
-    ...terms.shared.loopOutcomeTerms,
+  const gateSpecs = [
+    {
+      workflowName: "kiro-spec-ai-quality-gate",
+      terms: [
+        ...terms.specGeneration.reviewReports,
+        ...terms.specGeneration.optionalFixReports,
+        ...terms.shared.routingTerms,
+        ...terms.shared.catchAllTerms,
+        ...terms.shared.loopOutcomeTerms,
+        ...terms.shared.callTerms,
+      ],
+    },
+    {
+      workflowName: "kiro-discovery-ai-quality-gate",
+      terms: [
+        ...terms.discoveryArtifact.reviewReports,
+        ...terms.discoveryArtifact.optionalFixReports,
+        ...terms.shared.routingTerms,
+        ...terms.shared.catchAllTerms,
+        ...terms.shared.loopOutcomeTerms,
+        ...terms.shared.callTerms,
+      ],
+    },
   ];
   for (const language of languages) {
-    const path = workflowPath(repoRoot, language, "kiro-spec-ai-quality-gate");
+    for (const gateSpec of gateSpecs) {
+      const path = workflowPath(repoRoot, language, gateSpec.workflowName);
+      if (!existsSync(path)) {
+        failures.push(`GATE_CONTRACT_DRIFT: ${rel(repoRoot, path)} missing`);
+        continue;
+      }
+      const content = readText(path);
+      for (const term of gateSpec.terms) {
+        if (!content.includes(term)) {
+          failures.push(`GATE_CONTRACT_DRIFT: ${rel(repoRoot, path)} missing required gate contract term: ${term}`);
+        }
+      }
+    }
+  }
+  return { ok: failures.length === 0, failures };
+}
+
+function validateDiscoveryGateEvidenceInstructions(repoRoot) {
+  const failures = [];
+  const requiredTerms = [
+    "reports/subworkflows/iteration-*--step-ai-quality-gate-discovery--workflow-kiro-discovery-ai-quality-gate/kiro-discovery-ai-antipattern-review.md",
+    "reports/subworkflows/iteration-*--step-ai-quality-gate-discovery--workflow-kiro-discovery-ai-quality-gate/kiro-discovery-ai-antipattern-fix.md",
+    "namespaced",
+    "kiro-discovery-ai-antipattern-review.md",
+    "kiro-discovery-ai-antipattern-fix.md",
+    "unresolved",
+    "stale",
+    "cross-run",
+    "evidence-free",
+    "optional fix report",
+    "kiro-ai-antipattern-review.md",
+    "kiro-spec-ai-antipattern-review.md",
+  ];
+  for (const language of languages) {
+    const path = join(repoRoot, ".takt", language, "facets", "instructions", "kiro-discovery.md");
     if (!existsSync(path)) {
-      failures.push(`GATE_CONTRACT_DRIFT: ${rel(repoRoot, path)} missing`);
+      failures.push(`DISCOVERY_GATE_EVIDENCE_DRIFT: ${rel(repoRoot, path)} missing`);
       continue;
     }
     const content = readText(path);
-    for (const term of specTerms) {
+    for (const term of requiredTerms) {
       if (!content.includes(term)) {
-        failures.push(`GATE_CONTRACT_DRIFT: ${rel(repoRoot, path)} missing required gate contract term: ${term}`);
+        failures.push(`DISCOVERY_GATE_EVIDENCE_DRIFT: ${rel(repoRoot, path)} missing required discovery gate evidence term: ${term}`);
       }
     }
   }
@@ -391,6 +475,7 @@ export function validateKiroAiQualityGateWorkflowCoverage(options = {}) {
     gatePlacement: validateGatePlacement(repoRoot, coverageEntries),
     readOnlyAndDelegatedBoundaries: validateReadOnlyAndDelegatedBoundaries(repoRoot, coverageEntries),
     gateContractTerms: validateGateContractTerms(repoRoot),
+    discoveryGateEvidenceInstructions: validateDiscoveryGateEvidenceInstructions(repoRoot),
     downstreamGateEvidenceInstructions: validateDownstreamGateEvidenceInstructions(repoRoot),
     quickGateEvidenceInstructions: validateQuickGateEvidenceInstructions(repoRoot),
     policyFacetBoundaries: validatePolicyFacetBoundaries(repoRoot, coverageEntries),

--- a/scripts/validate-kiro-discovery-batch-workflows.mjs
+++ b/scripts/validate-kiro-discovery-batch-workflows.mjs
@@ -3,6 +3,7 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getAllowedKiroAiQualityGateCallSites } from "./kiro-ai-quality-gate-contracts.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -20,13 +21,25 @@ const actionPathEnums = [
 const workflowSpecs = [
   {
     file: "kiro-discovery.yaml",
-    expectedSteps: ["classify-action-path", "plan-discovery-artifacts", "write-discovery-artifacts", "report-discovery"],
-    instructions: ["kiro-discovery"],
+    expectedSteps: [
+      "classify-action-path",
+      "plan-discovery-artifacts",
+      "write-discovery-artifacts",
+      "ai-quality-gate-discovery",
+      "report-discovery",
+    ],
+    instructions: ["kiro-discovery", "kiro-ai-antipattern-fix-discovery"],
     policies: ["kiro-discovery-routing"],
     reports: ["kiro-discovery-result"],
     requiredTerms: [
       "brief.md",
       ".kiro/steering/roadmap.md",
+      "workflow_call",
+      "kiro-discovery-ai-quality-gate",
+      "ai-quality-gate-discovery",
+      "need_replan",
+      "loop_monitors",
+      "loop_monitors.threshold",
       "required plannedFiles missing",
       "required createdFiles missing",
       "required discovery artifacts missing",
@@ -64,6 +77,22 @@ const facetSpecs = [
     skill: "kiro-discovery",
     skillSection: "## Step 2: Determine Action Path",
     terms: ["brief.md", ".kiro/steering/roadmap.md", "blockingReason", "ready_for_implementation", ...actionPathEnums],
+  },
+  {
+    kind: "instructions",
+    file: "kiro-ai-antipattern-fix-discovery.md",
+    parent: "fix",
+    terms: [
+      "kiro-discovery-ai-antipattern-review.md",
+      "kiro-discovery-ai-antipattern-fix.md",
+      "current discovery artifact boundary",
+      "brief.md",
+      ".kiro/steering/roadmap.md",
+      "FIXED",
+      "NO_FIX_NEEDED",
+      "NEED_REPLAN",
+      "BLOCKED",
+    ],
   },
   {
     kind: "instructions",
@@ -115,6 +144,22 @@ const facetSpecs = [
   },
   {
     kind: "output-contracts",
+    file: "kiro-discovery-ai-antipattern-fix-result.md",
+    parent: "validation",
+    terms: [
+      "STATUS",
+      "finding_decisions",
+      "changed_files",
+      "scope_guard",
+      "validation_evidence",
+      "no_fix_rationale",
+      "missing_context",
+      "kiro-discovery-ai-antipattern-fix.md",
+      "optional fix report",
+    ],
+  },
+  {
+    kind: "output-contracts",
     file: "kiro-batch-summary.md",
     parent: "validation",
     terms: ["wavePlan", "skippedSpecReady", "featureResults", "failedFeatures", "crossSpecReview", "implementationReady"],
@@ -163,6 +208,52 @@ function parseFacetParent(content) {
 
 function getStepNames(content) {
   return [...content.matchAll(/^  - name:\s*(.+)\s*$/gm)].map((match) => match[1]);
+}
+
+function stepBlocks(content) {
+  const lines = content.split("\n");
+  const blocks = [];
+  let current = null;
+  for (const line of lines) {
+    if (/^  - name:\s+/.test(line)) {
+      if (current) {
+        blocks.push(current);
+      }
+      current = [line];
+    } else if (current) {
+      if (/^\S/.test(line)) {
+        blocks.push(current);
+        current = null;
+      } else {
+        current.push(line);
+      }
+    }
+  }
+  if (current) {
+    blocks.push(current);
+  }
+  return blocks;
+}
+
+function stepScalar(block, key) {
+  if (key === "name") {
+    return block.join("\n").match(/^  - name:\s*(.+)\s*$/m)?.[1] ?? "";
+  }
+  return block.join("\n").match(new RegExp(`^    ${key}:\\s*(.+)\\s*$`, "m"))?.[1] ?? "";
+}
+
+function validateApprovedWorkflowCalls(repoRoot, path, workflowName, content) {
+  const failures = [];
+  const allowedSites = getAllowedKiroAiQualityGateCallSites().filter((site) => site.workflowName === workflowName);
+  for (const block of stepBlocks(content).filter((candidate) => stepScalar(candidate, "kind") === "workflow_call")) {
+    const stepName = stepScalar(block, "name");
+    const callPath = stepScalar(block, "call");
+    const allowed = allowedSites.some((site) => site.stepName === stepName && site.callPath === callPath);
+    if (!allowed) {
+      failures.push(`WORKFLOW_DRIFT: ${rel(repoRoot, path)} must not use unapproved workflow_call ${stepName} -> ${callPath}`);
+    }
+  }
+  return failures;
 }
 
 function extractMachineTokens(content) {
@@ -227,9 +318,7 @@ function validateWorkflow(repoRoot, lang, spec) {
       failures.push(`WORKFLOW_DRIFT: ${rel(repoRoot, path)} missing report format ${report}`);
     }
   }
-  if (/\bworkflow_call\b/.test(content)) {
-    failures.push(`WORKFLOW_DRIFT: ${rel(repoRoot, path)} must not use workflow_call for phase reuse`);
-  }
+  failures.push(...validateApprovedWorkflowCalls(repoRoot, path, spec.file.replace(/\.yaml$/, ""), content));
   if (/\btakt\s+-w\b|\btakt\s+.*\s-w\s+/.test(content)) {
     failures.push(`WORKFLOW_DRIFT: ${rel(repoRoot, path)} must not use shell takt -w for phase reuse`);
   }

--- a/tests/kiro-ai-quality-gate-runtime-smoke.test.mjs
+++ b/tests/kiro-ai-quality-gate-runtime-smoke.test.mjs
@@ -27,6 +27,7 @@ function makeRuntimeFixture() {
     `${JSON.stringify(
       {
         scripts: {
+          "kiro:discovery": "node scripts/kiro-staged.mjs kiro-discovery --pipeline --skip-git -t",
           "kiro:impl": "node scripts/kiro-staged.mjs kiro-impl --pipeline --skip-git -t",
           "kiro:spec:requirements": "node scripts/kiro-staged.mjs kiro-spec-requirements --pipeline --skip-git -t",
         },
@@ -41,6 +42,70 @@ function makeRuntimeFixture() {
     "provider: mock\nlanguage: ja\nmodel: claude-opus-4-8\nconcurrency: 1\nbase_branch: main\nsubmodules: all\n",
   );
   return root;
+}
+
+function writeDiscoverySmokeContext(root) {
+  writeFixtureFile(root, ".kiro/steering/product.md", "# Product\n\nRuntime smoke fixture.\n");
+  writeFixtureFile(root, ".kiro/steering/roadmap.md", "# Roadmap\n\n## Specs (dependency order)\n");
+}
+
+function writeDiscoveryMockScenario(root) {
+  const entries = [
+    {
+      persona: "planner",
+      content:
+        "## Discovery Classification\n\nactionPath: SINGLE_SPEC\nreason: deterministic discovery runtime smoke\nplannedFiles: [.kiro/specs/kiro-discovery-ai-quality-gate-smoke/brief.md]\ncreatedFiles: []\nblockingReason: none\nsummary: classify as single spec",
+    },
+    {
+      persona: "planner",
+      content:
+        "## Kiro Discovery Result\n\nactionPath: SINGLE_SPEC\nreason: deterministic discovery runtime smoke\nplannedFiles: [.kiro/specs/kiro-discovery-ai-quality-gate-smoke/brief.md]\ncreatedFiles: []\nnextAction: write discovery artifact\nblockingReason: none\nawarenessOnlyItems: []\nsummary: classify as single spec",
+    },
+    { persona: "conductor", content: '{"step":3}', structured_output: { step: 3 } },
+    {
+      persona: "planner",
+      content:
+        "## Discovery Plan\n\nactionPath: SINGLE_SPEC\nplannedFiles: [.kiro/specs/kiro-discovery-ai-quality-gate-smoke/brief.md]\nblockingReason: none\nsummary: plan brief artifact",
+    },
+    {
+      persona: "planner",
+      content:
+        "## Kiro Discovery Result\n\nactionPath: SINGLE_SPEC\nreason: deterministic discovery runtime smoke\nplannedFiles: [.kiro/specs/kiro-discovery-ai-quality-gate-smoke/brief.md]\ncreatedFiles: []\nnextAction: write discovery artifact\nblockingReason: none\nawarenessOnlyItems: []\nsummary: plan brief artifact",
+    },
+    { persona: "conductor", content: '{"step":2}', structured_output: { step: 2 } },
+    {
+      persona: "planner",
+      content:
+        "## Discovery Write\n\nactionPath: SINGLE_SPEC\ncreatedFiles: [.kiro/specs/kiro-discovery-ai-quality-gate-smoke/brief.md]\nblockingReason: none\nsummary: discovery artifact written",
+    },
+    {
+      persona: "planner",
+      content:
+        "## Kiro Discovery Result\n\nactionPath: SINGLE_SPEC\nreason: deterministic discovery runtime smoke\nplannedFiles: [.kiro/specs/kiro-discovery-ai-quality-gate-smoke/brief.md]\ncreatedFiles: [.kiro/specs/kiro-discovery-ai-quality-gate-smoke/brief.md]\nnextAction: run discovery AI quality gate\nblockingReason: none\nawarenessOnlyItems: []\nsummary: discovery artifact written",
+    },
+    { persona: "conductor", content: '{"step":2}', structured_output: { step: 2 } },
+    { persona: "ai-antipattern-reviewer", content: "Discovery AI antipattern smoke review complete. No AI-specific issues." },
+    {
+      persona: "ai-antipattern-reviewer",
+      content:
+        "# Discovery AI Antipattern Review\n\n## Result: APPROVE\n\nNo AI-specific issues.\n\nNo fix report is required for this successful smoke path.",
+    },
+    { persona: "conductor", content: '{"step":1}', structured_output: { step: 1 } },
+    {
+      persona: "supervisor",
+      content:
+        "## Discovery Final Report\n\nactionPath: SINGLE_SPEC\nreason: deterministic discovery runtime smoke\nplannedFiles: [.kiro/specs/kiro-discovery-ai-quality-gate-smoke/brief.md]\ncreatedFiles: [.kiro/specs/kiro-discovery-ai-quality-gate-smoke/brief.md]\nnextAction: run kiro-spec-init\nblockingReason: none\nawarenessOnlyItems: []\ndiscovery AI quality gate passed\nsummary: report discovery after gate",
+    },
+    {
+      persona: "supervisor",
+      content:
+        "## Kiro Discovery Result\n\nactionPath: SINGLE_SPEC\nreason: deterministic discovery runtime smoke\nplannedFiles: [.kiro/specs/kiro-discovery-ai-quality-gate-smoke/brief.md]\ncreatedFiles: [.kiro/specs/kiro-discovery-ai-quality-gate-smoke/brief.md]\nnextAction: run kiro-spec-init\nblockingReason: none\nawarenessOnlyItems: []\ndiscovery AI quality gate passed\nsummary: report discovery after gate",
+    },
+    { persona: "conductor", content: '{"step":3}', structured_output: { step: 3 } },
+  ];
+  const scenarioPath = join(root, ".takt", "runs", "kiro-discovery-ai-quality-gate-runtime-smoke-scenario.json");
+  writeFixtureFile(root, ".takt/runs/kiro-discovery-ai-quality-gate-runtime-smoke-scenario.json", `${JSON.stringify(entries, null, 2)}\n`);
+  return scenarioPath;
 }
 
 function writeRequirementsSmokeSpec(root) {
@@ -369,6 +434,51 @@ test("kiro spec generation runtime wiring calls spec AI gate before requirements
     assert.match(readFileSync(specAiReportPath, "utf8"), /No AI-specific issues/);
     assert.equal(findFile(reportsDir, "kiro-spec-ai-antipattern-fix.md"), undefined);
     assert.match(readFileSync(join(reportsDir, "kiro-spec-requirements-review.md"), "utf8"), /requirements review gate passed/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("kiro discovery runtime wiring calls discovery AI gate before report", () => {
+  const root = makeRuntimeFixture();
+  try {
+    writeDiscoverySmokeContext(root);
+    const scenarioPath = writeDiscoveryMockScenario(root);
+
+    const result = spawnSync(
+      "npm",
+      ["run", "kiro:discovery", "--", "Create a smoke feature brief for kiro-discovery-ai-quality-gate-smoke"],
+      {
+        cwd: root,
+        env: {
+          ...process.env,
+          TAKT_MOCK_SCENARIO: scenarioPath,
+        },
+        encoding: "utf8",
+      },
+    );
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    assert.equal(result.status, 0, output);
+    assert.match(output, /\[3\/12\] write-discovery-artifacts/);
+    assert.match(output, /\[4\/12\] ai-quality-gate-discovery/);
+    assert.match(output, /\[5\/12\] ai-antipattern-review-1st/);
+    assert.match(output, /Status: COMPLETE/);
+    assert.match(output, /\[6\/12\] report-discovery/);
+    assert.match(output, /Result: Success/);
+
+    const reportRoot = join(root, ".takt", "runs");
+    const latestRun = readdirSync(reportRoot)
+      .filter((entry) => statSync(join(reportRoot, entry)).isDirectory())
+      .sort()
+      .at(-1);
+    assert.ok(latestRun, output);
+    const reportsDir = join(reportRoot, latestRun, "reports");
+    const discoveryAiReportPath = findFile(reportsDir, "kiro-discovery-ai-antipattern-review.md");
+    assert.ok(discoveryAiReportPath, "expected the discovery AI antipattern review report to be emitted");
+    assert.match(readFileSync(discoveryAiReportPath, "utf8"), /No AI-specific issues/);
+    assert.equal(findFile(reportsDir, "kiro-discovery-ai-antipattern-fix.md"), undefined);
+    assert.match(readFileSync(join(reportsDir, "kiro-discovery-result.md"), "utf8"), /discovery AI quality gate passed/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tests/kiro-ai-quality-gate-workflow-coverage.test.mjs
+++ b/tests/kiro-ai-quality-gate-workflow-coverage.test.mjs
@@ -58,7 +58,9 @@ test("kiro AI quality gate coverage inventory records current Kiro workflow boun
   assert.equal(byName.get("kiro-spec-requirements").allowedGateCall, "./kiro-spec-ai-quality-gate.yaml");
   assert.equal(byName.get("kiro-spec-quick").category, "generation_scoped_gate_required");
   assert.equal(byName.get("kiro-spec-init").category, "intentionally_not_applicable");
-  assert.equal(byName.get("kiro-discovery").category, "orchestration_delegated");
+  assert.equal(byName.get("kiro-discovery").category, "discovery_artifact_gate_required");
+  assert.equal(byName.get("kiro-discovery").allowedGateCall, "./kiro-discovery-ai-quality-gate.yaml");
+  assert.equal(byName.get("kiro-discovery-ai-quality-gate").category, "existing_gate_coverage");
   assert.equal(byName.get("kiro-spec-batch").category, "orchestration_delegated");
 
   for (const name of ["kiro-spec-status", "kiro-validate-design", "kiro-validate-gap", "kiro-validate-impl"]) {
@@ -66,21 +68,36 @@ test("kiro AI quality gate coverage inventory records current Kiro workflow boun
   }
 });
 
-test("orchestration workflows delegate artifact-level AI review without direct AI gate calls", () => {
+test("batch orchestration delegates artifact-level AI review without direct AI gate calls", () => {
   const byName = new Map(getKiroWorkflowCoverageEntries().map((entry) => [entry.workflowName, entry]));
 
-  for (const workflowName of ["kiro-discovery", "kiro-spec-batch"]) {
-    const entry = byName.get(workflowName);
-    assert.equal(entry.category, "orchestration_delegated");
-    assert.match(entry.adjacentOwner, /kiro-spec-/);
-    assert.equal(entry.allowedGateCall, undefined);
+  const entry = byName.get("kiro-spec-batch");
+  assert.equal(entry.category, "orchestration_delegated");
+  assert.match(entry.adjacentOwner, /kiro-spec-/);
+  assert.equal(entry.allowedGateCall, undefined);
 
-    for (const language of languages) {
-      const path = join(repoRoot, ".takt", language, "workflows", `${workflowName}.yaml`);
-      const content = readFileSync(path, "utf8");
-      assert.equal(content.includes("kiro-ai-quality-gate"), false, `${path} must not call implementation AI gate`);
-      assert.equal(content.includes("kiro-spec-ai-quality-gate"), false, `${path} must not call spec AI gate directly`);
-    }
+  for (const language of languages) {
+    const path = join(repoRoot, ".takt", language, "workflows", "kiro-spec-batch.yaml");
+    const content = readFileSync(path, "utf8");
+    assert.equal(content.includes("kiro-ai-quality-gate"), false, `${path} must not call implementation AI gate`);
+    assert.equal(content.includes("kiro-spec-ai-quality-gate"), false, `${path} must not call spec AI gate directly`);
+  }
+});
+
+test("discovery workflow routes discovery artifacts through discovery AI quality gate", () => {
+  for (const language of languages) {
+    const path = join(repoRoot, ".takt", language, "workflows", "kiro-discovery.yaml");
+    const content = readFileSync(path, "utf8");
+
+    assert.match(content, /- name: ai-quality-gate-discovery[\s\S]*kind: workflow_call[\s\S]*call: \.\/kiro-discovery-ai-quality-gate\.yaml/);
+    assert.match(content, /- name: write-discovery-artifacts[\s\S]*createdFiles include target brief\.md and actionPath SINGLE_SPEC[\s\S]*next: ai-quality-gate-discovery/);
+    assert.match(content, /- name: ai-quality-gate-discovery[\s\S]*condition: COMPLETE[\s\S]*next: report-discovery/);
+    assert.match(content, /- name: ai-quality-gate-discovery[\s\S]*condition: need_replan[\s\S]*next: plan-discovery-artifacts/);
+    assert.ok(content.includes("- plan-discovery-artifacts"), `${path} loop monitor should include plan-discovery-artifacts`);
+    assert.ok(content.includes("- write-discovery-artifacts"), `${path} loop monitor should include write-discovery-artifacts`);
+    assert.ok(content.includes("- ai-quality-gate-discovery"), `${path} loop monitor should include ai-quality-gate-discovery`);
+    assert.equal(content.includes("kiro-ai-antipattern-fix-implementation"), false, `${path} must not use implementation fix instruction`);
+    assert.equal(content.includes("kiro-spec-ai-antipattern-review.md"), false, `${path} must not use spec generation report names`);
   }
 });
 
@@ -89,6 +106,7 @@ test("kiro AI quality gate coverage policy facets explain categories without dup
   const requiredTerms = [
     "scripts/kiro-ai-quality-gate-contracts.mjs",
     "existing_gate_coverage",
+    "discovery_artifact_gate_required",
     "generation_scoped_gate_required",
     "orchestration_decision_required",
     "orchestration_delegated",
@@ -135,6 +153,92 @@ test("spec generation AI quality gate workflow is callable and separates spec re
       assert.ok(content.includes(term), `${path} should include ${term}`);
     }
     assert.equal(content.includes("kiro-ai-antipattern-review.md"), false, `${path} should not reuse implementation review report name`);
+  }
+});
+
+test("discovery AI quality gate workflow is callable and separates discovery reports from other gate reports", () => {
+  const requiredTerms = [
+    "subworkflow:",
+    "callable: true",
+    "visibility: internal",
+    "kiro-discovery-ai-antipattern-review.md",
+    "kiro-discovery-ai-antipattern-fix.md",
+    "No AI-specific issues",
+    "AI-specific issues found",
+    "request-replan",
+    "ambiguous",
+    "blocked",
+    "internally inconsistent",
+    "return: need_replan",
+  ];
+
+  for (const language of languages) {
+    const path = join(repoRoot, ".takt", language, "workflows", "kiro-discovery-ai-quality-gate.yaml");
+    const content = readFileSync(path, "utf8");
+
+    for (const term of requiredTerms) {
+      assert.ok(content.includes(term), `${path} should include ${term}`);
+    }
+    assert.equal(content.includes("kiro-ai-antipattern-review.md"), false, `${path} should not reuse implementation review report name`);
+    assert.equal(content.includes("kiro-spec-ai-antipattern-review.md"), false, `${path} should not reuse spec generation review report name`);
+  }
+});
+
+test("discovery AI quality gate uses discovery-specific fix instruction and output contract", () => {
+  const requiredInstructionTerms = [
+    "kiro-discovery-ai-antipattern-review.md",
+    "kiro-discovery-ai-antipattern-fix.md",
+    "current discovery artifact boundary",
+    "brief.md",
+    ".kiro/steering/roadmap.md",
+    "FIXED",
+    "NO_FIX_NEEDED",
+    "NEED_REPLAN",
+    "BLOCKED",
+  ];
+  const requiredContractTerms = [
+    "STATUS",
+    "finding_decisions",
+    "changed_files",
+    "scope_guard",
+    "validation_evidence",
+    "no_fix_rationale",
+    "missing_context",
+    "kiro-discovery-ai-antipattern-fix.md",
+    "optional fix report",
+  ];
+
+  for (const language of languages) {
+    const workflowPath = join(repoRoot, ".takt", language, "workflows", "kiro-discovery-ai-quality-gate.yaml");
+    const workflowContent = readFileSync(workflowPath, "utf8");
+    assert.ok(workflowContent.includes("kiro-ai-antipattern-fix-discovery"));
+    assert.ok(workflowContent.includes("kiro-discovery-ai-antipattern-fix-result"));
+
+    const instructionPath = join(
+      repoRoot,
+      ".takt",
+      language,
+      "facets",
+      "instructions",
+      "kiro-ai-antipattern-fix-discovery.md",
+    );
+    const instructionContent = readFileSync(instructionPath, "utf8");
+    for (const term of requiredInstructionTerms) {
+      assert.ok(instructionContent.includes(term), `${instructionPath} should include ${term}`);
+    }
+
+    const contractPath = join(
+      repoRoot,
+      ".takt",
+      language,
+      "facets",
+      "output-contracts",
+      "kiro-discovery-ai-antipattern-fix-result.md",
+    );
+    const contractContent = readFileSync(contractPath, "utf8");
+    for (const term of requiredContractTerms) {
+      assert.ok(contractContent.includes(term), `${contractPath} should include ${term}`);
+    }
   }
 });
 
@@ -614,6 +718,8 @@ test("repository scripts and CI run Kiro AI quality gate coverage checks", () =>
     "test:kiro-ai-quality-gate-workflow-coverage":
       "node --test tests/kiro-ai-quality-gate-workflow-coverage.test.mjs",
     "test:kiro-ai-quality-gate-runtime-smoke": "node --test tests/kiro-ai-quality-gate-runtime-smoke.test.mjs",
+    "test:kiro-discovery-ai-quality-gate-runtime-smoke":
+      'node --test --test-name-pattern "kiro discovery runtime wiring" tests/kiro-ai-quality-gate-runtime-smoke.test.mjs',
   };
 
   for (const [scriptName, command] of Object.entries(requiredScripts)) {


### PR DESCRIPTION
## Summary

- Add a discovery-scoped callable AI quality gate workflow for `kiro-discovery` in both English and Japanese TAKT assets.
- Route discovery artifact writes through `ai-quality-gate-discovery` before `report-discovery`, with discovery-specific fix instructions and report contracts.
- Extend the shared coverage inventory, allowlist validators, unit tests, runtime smoke coverage, npm scripts, and CI wiring.
- Complete the `kiro-ai-quality-gate-workflow-coverage` spec tasks.

## Validation

- `npm run validate:kiro-ai-quality-gate-workflow-coverage`
- `npm run test:kiro-ai-quality-gate-workflow-coverage`
- `npm run validate:kiro-discovery-batch-workflows`
- `npm run test:kiro-discovery-batch-workflows`
- `npm run validate:kiro-shared-contracts`
- `npm run test:kiro-shared-contracts`
- `npm run validate:kiro-spec-generation-workflows`
- `npm run test:kiro-spec-generation-workflows`
- `npm run validate:kiro-status-validation-workflows`
- `npm run test:kiro-status-validation-workflows`
- `npm run test:kiro-ai-quality-gate-runtime-smoke`
- `npm run test:kiro-discovery-ai-quality-gate-runtime-smoke`
- `takt prompt` over all `.takt/{en,ja}/workflows/*.yaml`
- `npm ci --ignore-scripts && npm run build` in `installer/`
- `node installer/dist/cli.js --dry-run --lang en`
- `node installer/dist/cli.js --dry-run --lang ja`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `kiro-discovery` routing and artifact promotion boundaries; mitigated by allowlist validators, en/ja parity checks, and deterministic runtime smoke, but workflow regressions could block or mis-route discovery runs.
> 
> **Overview**
> Adds a **discovery-scoped AI antipattern quality gate** so `kiro-discovery` no longer reports completion right after writing `brief.md` / roadmap artifacts. Successful `SINGLE_SPEC`, `MULTI_SPEC`, and `MIXED_DECOMPOSITION` paths now call **`ai-quality-gate-discovery`** (`./kiro-discovery-ai-quality-gate.yaml`) before `report-discovery`; artifact-less paths still skip the gate.
> 
> The new callable subworkflow (en/ja) uses discovery-specific fix instructions and reports (`kiro-discovery-ai-antipattern-review.md` / optional fix), bounded to discovery artifacts—not implementation or spec-generation gates. **`report-discovery`** and **`kiro-discovery`** facets require namespaced gate evidence and reject wrong report types or stale/cross-run evidence.
> 
> **Coverage** moves `kiro-discovery` from orchestration-delegated to **`discovery_artifact_gate_required`** in `kiro-ai-quality-gate-contracts.mjs`, with validators enforcing placement, loop monitors (`plan → write → gate`), and an allowlisted `workflow_call` in discovery/batch validation (batch still has no direct gate). **Tests**, a **discovery runtime smoke** npm script, and **CI** wire the new checks in alongside existing Kiro quality-gate validation. Spec/tasks under `kiro-ai-quality-gate-workflow-coverage` are updated to document the discovery gate slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ec869ddf58695b4f0ae4cbee72bf0b4612cf19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->