### PR TITLE
test(kiro): add real provider smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
           npm run test:kiro-iterative-implementation-workflow
           npm run test:kiro-ai-quality-gate-runtime-smoke
           npm run test:kiro-discovery-ai-quality-gate-runtime-smoke
+          npm run test:kiro-real-provider-smoke
 
       - name: Validate workflows (ja)
         run: |

--- a/README.ja.md
+++ b/README.ja.md
@@ -142,6 +142,17 @@ npm run kiro:impl -- "feature={feature}"
 npm run kiro:validate:impl -- "feature={feature}"
 ```
 
+### Smoke Tests
+
+mock provider の smoke tests は CI で実行される。実 Claude provider で Kiro full lifecycle を流す場合は、明示的に opt-in する：
+
+```bash
+KIRO_REAL_PROVIDER_SMOKE=1 npm run test:kiro-real-provider-smoke
+```
+
+timeout のデフォルトは workflow ごとに 15 分、`kiro:impl` は 30 分。
+実 provider 実行が遅い場合は `KIRO_REAL_PROVIDER_TIMEOUT_MS` または `KIRO_REAL_PROVIDER_IMPL_TIMEOUT_MS` で調整できる。
+
 ### 旧 `cc-sdd:*` scripts からの移行
 
 旧 scripts は互換入口として残る。既存の `cc-sdd-*` workflow を呼び続け、`kiro:*` の alias ではない。

--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ npm run kiro:impl -- "feature={feature}"
 npm run kiro:validate:impl -- "feature={feature}"
 ```
 
+### Smoke Tests
+
+Mock-provider smoke tests run in CI. To run the full Kiro lifecycle against the real Claude provider, opt in explicitly:
+
+```bash
+KIRO_REAL_PROVIDER_SMOKE=1 npm run test:kiro-real-provider-smoke
+```
+
+The default timeout is 15 minutes per workflow, with 30 minutes for `kiro:impl`.
+Use `KIRO_REAL_PROVIDER_TIMEOUT_MS` or `KIRO_REAL_PROVIDER_IMPL_TIMEOUT_MS` to tune slow real-provider runs.
+
 ### Migration from legacy `cc-sdd:*` scripts
 
 Legacy scripts are compatibility entrypoints. They continue to call the existing `cc-sdd-*` workflows and are not aliases for `kiro:*`.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:kiro-iterative-implementation-workflow": "node --test tests/kiro-iterative-implementation-workflow.test.mjs",
     "test:kiro-ai-quality-gate-runtime-smoke": "node --test tests/kiro-ai-quality-gate-runtime-smoke.test.mjs",
     "test:kiro-discovery-ai-quality-gate-runtime-smoke": "node --test --test-name-pattern \"kiro discovery runtime wiring\" tests/kiro-ai-quality-gate-runtime-smoke.test.mjs",
+    "test:kiro-real-provider-smoke": "node --test tests/kiro-real-provider-smoke.test.mjs",
     "cc-sdd:full": "scripts/takt.sh --pipeline --skip-git -w cc-sdd-full -t",
     "cc-sdd:requirements": "scripts/takt.sh --pipeline --skip-git -w cc-sdd-requirements -t",
     "cc-sdd:validate-gap": "scripts/takt.sh --pipeline --skip-git -w cc-sdd-validate-gap -t",

--- a/tests/kiro-real-provider-smoke.test.mjs
+++ b/tests/kiro-real-provider-smoke.test.mjs
@@ -288,6 +288,7 @@ test("real provider smoke runner cleans up detached fixture processes on fail-fa
       "package.json",
       `${JSON.stringify(
         {
+          type: "module",
           scripts: {
             orphan: "node orphan-parent.js",
           },

--- a/tests/kiro-real-provider-smoke.test.mjs
+++ b/tests/kiro-real-provider-smoke.test.mjs
@@ -1,0 +1,356 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawn, spawnSync } from "node:child_process";
+
+// Real-provider smoke intentionally uses semantic assertions instead of exact
+// generated text because Claude output can vary. Mock-provider smoke tests
+// should stay strict and deterministic.
+const featureName = "kiro-real-provider-smoke";
+const defaultModel = "claude-opus-4-8";
+const defaultWorkflowTimeoutMs = 900000;
+const defaultImplWorkflowTimeoutMs = 1800000;
+const fatalWorkflowPatterns = [
+  /\[ERROR\]/,
+  /Workflow aborted/i,
+  /Result:\s*Failed/i,
+  /^Status:.*\b(?:ABORT|BLOCKED|NEEDS_FIX|NO-GO)\b/im,
+];
+
+function writeFixtureFile(root, path, content) {
+  const fullPath = join(root, path);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content);
+}
+
+function makeRealProviderFixture() {
+  const root = mkdtempSync(join(tmpdir(), "kiro-real-provider-smoke-"));
+  const repoRoot = join(import.meta.dirname, "..");
+
+  cpSync(join(repoRoot, ".takt"), join(root, ".takt"), { recursive: true });
+  rmSync(join(root, ".takt", "runs"), { recursive: true, force: true });
+  symlinkSync(join(repoRoot, ".agents"), join(root, ".agents"), "dir");
+  symlinkSync(join(repoRoot, "node_modules"), join(root, "node_modules"), "dir");
+  mkdirSync(join(root, ".kiro"), { recursive: true });
+  cpSync(join(repoRoot, ".kiro", "settings"), join(root, ".kiro", "settings"), { recursive: true });
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  cpSync(join(repoRoot, "scripts", "kiro-staged.mjs"), join(root, "scripts", "kiro-staged.mjs"));
+  cpSync(join(repoRoot, "scripts", "takt.sh"), join(root, "scripts", "takt.sh"));
+  writeFixtureFile(
+    root,
+    "package.json",
+    `${JSON.stringify(
+      {
+        scripts: {
+          "kiro:impl": "node scripts/kiro-staged.mjs kiro-impl --pipeline --skip-git -t",
+          "kiro:spec:init": "node scripts/kiro-staged.mjs kiro-spec-init --pipeline --skip-git -t",
+          "kiro:spec:requirements": "node scripts/kiro-staged.mjs kiro-spec-requirements --pipeline --skip-git -t",
+          "kiro:spec:design": "node scripts/kiro-staged.mjs kiro-spec-design --pipeline --skip-git -t",
+          "kiro:spec:tasks": "node scripts/kiro-staged.mjs kiro-spec-tasks --pipeline --skip-git -t",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFixtureFile(
+    root,
+    ".takt/config.yaml",
+    `provider: claude
+language: ja
+model: ${process.env.KIRO_REAL_PROVIDER_MODEL ?? defaultModel}
+concurrency: 1
+base_branch: main
+submodules: all
+`,
+  );
+  writeFixtureFile(root, ".kiro/steering/product.md", "# Product\n\nReal-provider smoke fixture for TAKT/Kiro workflow validation.\n");
+  writeFixtureFile(root, ".kiro/steering/tech.md", "# Tech\n\nUse only local files in this temporary fixture.\n");
+  writeFixtureFile(root, ".kiro/steering/structure.md", "# Structure\n\nSmoke artifacts may be written under `smoke-output/` only.\n");
+  writeFixtureFile(root, ".kiro/steering/roadmap.md", "# Roadmap\n\n## Specs (dependency order)\n");
+  writeFixtureFile(
+    root,
+    `.kiro/specs/${featureName}/brief.md`,
+    `# Brief
+
+Create a minimal Kiro full-chain smoke spec using the real Claude provider.
+
+The implementation must be tiny and deterministic:
+
+- Own only \`smoke-output/provider-smoke.txt\`.
+- The final implementation task should create or update that file with a short line containing \`claude provider smoke passed\`.
+- Do not change production files, package metadata, workflows, facets, scripts, or settings.
+- Keep requirements, design, and tasks minimal but valid.
+`,
+  );
+  return root;
+}
+
+function terminateProcessGroup(child, signal) {
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    child.kill(signal);
+  }
+}
+
+function fixtureProcessIds(root) {
+  const result = spawnSync("ps", ["-eo", "pid=,command="], { encoding: "utf8" });
+  if (result.status !== 0) {
+    return [];
+  }
+  return result.stdout
+    .split("\n")
+    .map((line) => {
+      const match = line.trim().match(/^(\d+)\s+(.+)$/);
+      return match ? { pid: Number(match[1]), command: match[2] } : undefined;
+    })
+    .filter(Boolean)
+    .filter((entry) => entry.pid !== process.pid && entry.command.includes(root))
+    .map((entry) => entry.pid);
+}
+
+function terminateFixtureProcesses(root, signal) {
+  for (const pid of fixtureProcessIds(root)) {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Process already exited.
+    }
+  }
+}
+
+function envTimeoutMs(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function workflowTimeoutMs(scriptName) {
+  if (scriptName === "kiro:impl") {
+    return envTimeoutMs(
+      "KIRO_REAL_PROVIDER_IMPL_TIMEOUT_MS",
+      envTimeoutMs("KIRO_REAL_PROVIDER_TIMEOUT_MS", defaultImplWorkflowTimeoutMs),
+    );
+  }
+  return envTimeoutMs("KIRO_REAL_PROVIDER_TIMEOUT_MS", defaultWorkflowTimeoutMs);
+}
+
+function runWorkflow(root, scriptName, target, options = {}) {
+  const env = { ...process.env };
+  delete env.TAKT_MOCK_SCENARIO;
+  const timeoutMs = options.timeoutMs ?? workflowTimeoutMs(scriptName);
+  const patterns = options.fatalPatterns ?? fatalWorkflowPatterns;
+
+  return new Promise((resolve) => {
+    const child = spawn("npm", ["run", scriptName, "--", target], {
+      cwd: root,
+      env,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    let earlyAbortReason = "";
+    let killTimer;
+
+    const abort = (reason) => {
+      if (earlyAbortReason) {
+        return;
+      }
+      earlyAbortReason = reason;
+      terminateProcessGroup(child, "SIGTERM");
+      terminateFixtureProcesses(root, "SIGTERM");
+      killTimer = setTimeout(() => {
+        terminateProcessGroup(child, "SIGKILL");
+        terminateFixtureProcesses(root, "SIGKILL");
+      }, 5000);
+    };
+
+    const onOutput = (chunk) => {
+      const text = chunk.toString();
+      output += text;
+      if (process.env.KIRO_REAL_PROVIDER_VERBOSE === "1") {
+        process.stderr.write(text);
+      }
+      const matchedPattern = patterns.find((pattern) => pattern.test(output));
+      if (matchedPattern) {
+        abort(`fatal workflow output matched ${matchedPattern}`);
+      }
+    };
+
+    child.stdout.on("data", onOutput);
+    child.stderr.on("data", onOutput);
+    child.on("error", (error) => {
+      output += `\n${error.message}`;
+      abort(`spawn error: ${error.message}`);
+    });
+
+    const timeout = setTimeout(() => abort(`workflow exceeded ${timeoutMs}ms`), timeoutMs);
+
+    child.on("close", (status, signal) => {
+      clearTimeout(timeout);
+      clearTimeout(killTimer);
+      if (earlyAbortReason) {
+        terminateFixtureProcesses(root, "SIGKILL");
+      }
+      resolve({
+        status,
+        signal,
+        earlyAbortReason,
+        output,
+      });
+    });
+  });
+}
+
+function assertWorkflowSuccess(result, name) {
+  assert.equal(result.earlyAbortReason, "", `${name} stopped early: ${result.earlyAbortReason}\n${result.output}`);
+  assert.equal(result.signal, null, `${name} was terminated by ${result.signal}\n${result.output}`);
+  assert.equal(result.status, 0, `${name} failed\n${result.output}`);
+  assert.match(result.output, /Result: Success/, `${name} did not report success\n${result.output}`);
+}
+
+function assertRealProviderWorkflowSuccess(result, name) {
+  assertWorkflowSuccess(result, name);
+}
+
+function assertRealProviderPhase(root, phase, requiredArtifacts = []) {
+  assert.equal(readSpec(root).phase, phase);
+  for (const artifact of requiredArtifacts) {
+    assert.ok(existsSync(join(root, ".kiro", "specs", featureName, artifact)), `expected ${artifact} for ${phase}`);
+  }
+}
+
+function hasGoDecision(report) {
+  return /(?:^|\n)\s*(?:-\s*)?`?DECISION`?\s*(?::|=)\s*`?GO`?\b/im.test(report);
+}
+
+function assertRealProviderSmokeOutcome(root) {
+  const reportsDir = latestReportsDir(root);
+  const finalReport = readFileSync(join(reportsDir, "kiro-final-implementation-validation.md"), "utf8");
+  assert.equal(hasGoDecision(finalReport), true, `expected final validation to report GO\n${finalReport}`);
+
+  const smokeOutput = readFileSync(join(root, "smoke-output", "provider-smoke.txt"), "utf8");
+  assert.match(smokeOutput, /claude provider smoke passed/i);
+}
+
+function readSpec(root) {
+  return JSON.parse(readFileSync(join(root, ".kiro", "specs", featureName, "spec.json"), "utf8"));
+}
+
+function latestReportsDir(root) {
+  const runRoot = join(root, ".takt", "runs");
+  const latestRun = readdirSync(runRoot)
+    .filter((entry) => statSync(join(runRoot, entry)).isDirectory())
+    .sort()
+    .at(-1);
+  assert.ok(latestRun, "expected at least one TAKT run directory");
+  return join(runRoot, latestRun, "reports");
+}
+
+test("real provider smoke runner stops when workflow output reports a fatal error", async () => {
+  const root = mkdtempSync(join(tmpdir(), "kiro-real-provider-fail-fast-"));
+  try {
+    writeFixtureFile(
+      root,
+      "package.json",
+      `${JSON.stringify(
+        {
+          scripts: {
+            fatal: "node fatal.js",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    writeFixtureFile(
+      root,
+      "fatal.js",
+      "console.log('[ERROR] Workflow aborted after fatal smoke finding'); setInterval(() => {}, 60000);\n",
+    );
+
+    const result = await runWorkflow(root, "fatal", "ignored", { timeoutMs: 60000 });
+
+    assert.match(result.earlyAbortReason, /fatal workflow output matched/);
+    assert.match(result.output, /\[ERROR\] Workflow aborted/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("real provider smoke runner cleans up detached fixture processes on fail-fast", async () => {
+  const root = mkdtempSync(join(tmpdir(), "kiro-real-provider-orphan-"));
+  try {
+    writeFixtureFile(
+      root,
+      "package.json",
+      `${JSON.stringify(
+        {
+          scripts: {
+            orphan: "node orphan-parent.js",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    writeFixtureFile(
+      root,
+      "orphan-parent.js",
+      `import { spawn } from "node:child_process";
+const child = spawn(process.execPath, ["${join(root, "orphan-child.js")}"], {
+  detached: true,
+  stdio: "ignore",
+});
+child.unref();
+console.log("[ERROR] Workflow aborted after detached child spawned");
+setInterval(() => {}, 60000);
+`,
+    );
+    writeFixtureFile(root, "orphan-child.js", "setInterval(() => {}, 60000);\n");
+
+    const result = await runWorkflow(root, "orphan", "ignored", { timeoutMs: 60000 });
+
+    assert.match(result.earlyAbortReason, /fatal workflow output matched/);
+    assert.deepEqual(fixtureProcessIds(root), []);
+  } finally {
+    terminateFixtureProcesses(root, "SIGKILL");
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test(
+  "kiro full lifecycle smoke runs with the real Claude provider",
+  { skip: process.env.KIRO_REAL_PROVIDER_SMOKE === "1" ? false : "set KIRO_REAL_PROVIDER_SMOKE=1 to call the real Claude provider" },
+  async () => {
+    const root = makeRealProviderFixture();
+    let success = false;
+    try {
+      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:init", featureName), "kiro:spec:init");
+      assertRealProviderPhase(root, "initialized", ["requirements.md", "spec.json"]);
+
+      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:requirements", `feature=${featureName} -y`), "kiro:spec:requirements");
+      assertRealProviderPhase(root, "requirements-generated", ["requirements.md"]);
+
+      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:design", `feature=${featureName} -y`), "kiro:spec:design");
+      assertRealProviderPhase(root, "design-generated", ["requirements.md", "design.md"]);
+
+      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:tasks", `feature=${featureName} -y`), "kiro:spec:tasks");
+      assertRealProviderPhase(root, "tasks-generated", ["requirements.md", "design.md", "tasks.md"]);
+      const tasksSpec = readSpec(root);
+      assert.equal(tasksSpec.ready_for_implementation, true);
+
+      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:impl", `feature=${featureName}`), "kiro:impl");
+      assertRealProviderSmokeOutcome(root);
+      success = true;
+    } finally {
+      if (success && process.env.KIRO_REAL_PROVIDER_KEEP !== "1") {
+        rmSync(root, { recursive: true, force: true });
+      } else {
+        console.error(`Real provider smoke fixture retained at: ${root}`);
+      }
+    }
+  },
+);

--- a/tests/kiro-real-provider-smoke.test.mjs
+++ b/tests/kiro-real-provider-smoke.test.mjs
@@ -142,9 +142,10 @@ function runWorkflow(root, scriptName, target, options = {}) {
   delete env.TAKT_MOCK_SCENARIO;
   const timeoutMs = options.timeoutMs ?? workflowTimeoutMs(scriptName);
   const patterns = options.fatalPatterns ?? fatalWorkflowPatterns;
+  const targetArgs = Array.isArray(target) ? target : [target];
 
   return new Promise((resolve) => {
-    const child = spawn("npm", ["run", scriptName, "--", target], {
+    const child = spawn("npm", ["run", scriptName, "--", ...targetArgs], {
       cwd: root,
       env,
       detached: true,
@@ -332,13 +333,13 @@ test(
       assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:init", featureName), "kiro:spec:init");
       assertRealProviderPhase(root, "initialized", ["requirements.md", "spec.json"]);
 
-      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:requirements", `feature=${featureName} -y`), "kiro:spec:requirements");
+      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:requirements", [`feature=${featureName}`, "-y"]), "kiro:spec:requirements");
       assertRealProviderPhase(root, "requirements-generated", ["requirements.md"]);
 
-      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:design", `feature=${featureName} -y`), "kiro:spec:design");
+      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:design", [`feature=${featureName}`, "-y"]), "kiro:spec:design");
       assertRealProviderPhase(root, "design-generated", ["requirements.md", "design.md"]);
 
-      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:tasks", `feature=${featureName} -y`), "kiro:spec:tasks");
+      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:tasks", [`feature=${featureName}`, "-y"]), "kiro:spec:tasks");
       assertRealProviderPhase(root, "tasks-generated", ["requirements.md", "design.md", "tasks.md"]);
       const tasksSpec = readSpec(root);
       assert.equal(tasksSpec.ready_for_implementation, true);

--- a/tests/kiro-real-provider-smoke.test.mjs
+++ b/tests/kiro-real-provider-smoke.test.mjs
@@ -301,7 +301,7 @@ test("real provider smoke runner cleans up detached fixture processes on fail-fa
       root,
       "orphan-parent.js",
       `import { spawn } from "node:child_process";
-const child = spawn(process.execPath, ["${join(root, "orphan-child.js")}"], {
+const child = spawn(process.execPath, [${JSON.stringify(join(root, "orphan-child.js"))}], {
   detached: true,
   stdio: "ignore",
 });


### PR DESCRIPTION
## Summary

- Add an opt-in real Claude provider smoke test for the full Kiro lifecycle.
- Keep CI deterministic by running the smoke script while skipping real provider calls unless `KIRO_REAL_PROVIDER_SMOKE=1` is set.
- Document real-provider smoke usage and timeout controls.

## Verification

- `npm run test:kiro-real-provider-smoke`
- `KIRO_REAL_PROVIDER_SMOKE=1 npm run test:kiro-real-provider-smoke`
  - Completed full lifecycle: init, requirements, design, tasks, impl.
  - Final validation reported GO.
  - Verified `smoke-output/provider-smoke.txt` contained `claude provider smoke passed`.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI wiring only; production workflows unchanged and real provider calls are opt-in outside default CI.
> 
> **Overview**
> Adds an **opt-in real Claude provider smoke** for the full Kiro lifecycle (`init` → requirements → design → tasks → `impl`), complementing existing mock-provider runtime smoke tests.
> 
> The new `test:kiro-real-provider-smoke` script runs in CI but **skips live API calls** unless `KIRO_REAL_PROVIDER_SMOKE=1`. The harness builds an isolated temp fixture (Claude provider, semantic assertions), fail-fast on fatal workflow output, timeouts (15m / 30m for impl), and cleanup of detached processes. README (EN/JA) documents opt-in usage and `KIRO_REAL_PROVIDER_TIMEOUT_MS` / `KIRO_REAL_PROVIDER_IMPL_TIMEOUT_MS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a497ae22795c9f00eb6d6269735ec2669c689ea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->