### PR TITLE
fix(release): keep the core takt-sdd release marked as Latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
           body: ${{ steps.changelog.outputs.clean_changelog }}
           draft: false
           prerelease: false
+          make_latest: "true"
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
@@ -94,5 +95,6 @@ jobs:
           body: ${{ steps.changelog.outputs.clean_changelog }}
           draft: false
           prerelease: false
+          make_latest: "false"
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

Every release run creates two GitHub releases: core (`takt-sdd vX.Y.Z`, tag `vX.Y.Z`) first, then installer (`create-takt-sdd vX.Y.Z`, tag `installer/vX.Y.Z`) seconds later. GitHub marks the most recently created release as **Latest** by default, so the repo's Latest badge has always ended up on the installer release — most visibly with v2.0.0, where the front page headlined "create-takt-sdd v2.0.0".

## Fix

Pin `make_latest` explicitly on both `softprops/action-gh-release` steps:

- core release: `make_latest: "true"`
- installer release: `make_latest: "false"`

## Notes

- v2.0.0 itself has already been repointed manually (`gh release edit v2.0.0 --latest`) — Latest now shows `takt-sdd v2.0.0`.
- 2-line change, no behavior change for tags, npm publish triggers, or release bodies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release metadata change with no impact on build artifacts, versioning, or publish logic.
> 
> **Overview**
> The release workflow creates two GitHub releases per version (core `takt-sdd` first, then installer `create-takt-sdd`). Because GitHub defaults **Latest** to the most recently created release, the installer release was winning the badge.
> 
> This PR sets **`make_latest: "true"`** on the core `softprops/action-gh-release` step and **`make_latest: "false"`** on the installer step so **Latest** stays on the core release going forward. Tags, changelog bodies, and other release steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ede9f3130ca6705dcf470470cd91b9fe5d8a094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->