### PR TITLE
[codex] Support parallel Kiro task waves

### DIFF
--- a/.takt/en/facets/instructions/kiro-impl-apply-wave-task.md
+++ b/.takt/en/facets/instructions/kiro-impl-apply-wave-task.md
@@ -1,0 +1,40 @@
+{extends: implement-after-tests}
+
+## Kiro Skill Source
+
+Before executing this instruction, invoke `$kiro-impl` or `/kiro-impl` and read the resolved `SKILL.md`.
+Apply the `## Step 3: Execute Implementation` section from `$kiro-impl` or `/kiro-impl` as this step's source of truth.
+Also read the `## Feature Flag Protocol` section.
+This facet defines only the adapter delta for the TAKT workflow.
+
+# Kiro Wave Result Apply Adapter
+
+## Kiro-specific delta
+
+Apply exactly one ready wave result into the main worktree so the existing selected-task quality gates can review it. This step converts a TeamLeader part result back into the normal `kiro-task-implementation-result.md` contract.
+
+## Apply rules
+
+1. Require `dispatch_mode: wave_apply` or a fresh `dispatch_mode: wave` aggregate with `wave_result_refs`.
+2. Select the first successful `wave_part_status` (`READY_FOR_REVIEW` or `COMPLETE`) whose `selected_task` is still unchecked in `tasks.md`.
+3. Re-read `tasks.md`, `task_worktree`, `task_branch`, and `baseline_dirty_files` immediately before applying.
+4. Apply or merge only that selected task's diff from `task_branch` into the main worktree.
+5. Stop with `STATUS: BLOCKED` if the main worktree changed outside `baseline_dirty_files`, if the task checkbox is no longer unchecked, if the branch conflicts, or if `changed_files` exceeds `_Boundary:_`.
+6. Preserve `RED_PHASE_OUTPUT`, `validation_evidence`, `changed_files`, `task_worktree`, `task_branch`, `wave_id`, and `wave_result_refs` in the parent result.
+7. Do not update task checkboxes, blocker notes, or `Implementation Notes`; existing review, verify, and progress steps own those gates.
+
+## Status Report
+
+- `STATUS`: `READY_FOR_REVIEW`, `BLOCKED`, or `NEEDS_CONTEXT`.
+- `dispatch_mode`: `wave_apply`.
+- `selected_task`: the single task applied to the main worktree.
+- `baseline_dirty_files`: pre-existing dirty files captured during dispatch.
+- `changed_files`: files changed inside the selected task boundary.
+- `validation_evidence`: commands, exit codes, and fresh results from the wave part plus any apply-time checks.
+- `RED_PHASE_OUTPUT`: required for behavioral tasks, otherwise `N/A`.
+- `task_worktree` and `task_branch`: source isolation state for the applied part.
+- `wave_result_refs`: remaining ready or blocked wave results.
+
+## Output mapping
+
+Emit `kiro-task-implementation-result.md` in `kiro-implementation-result` format. `STATUS: READY_FOR_REVIEW` routes to `ai-quality-gate`; failures route to `debug-task` so the selected task can fall back to normal single-task repair.

--- a/.takt/en/facets/instructions/kiro-impl-collect-wave-results.md
+++ b/.takt/en/facets/instructions/kiro-impl-collect-wave-results.md
@@ -1,0 +1,37 @@
+{extends: implement-after-tests}
+
+## Kiro Skill Source
+
+Before executing this instruction, invoke `$kiro-impl` or `/kiro-impl` and read the resolved `SKILL.md`.
+Apply the `## Step 3: Execute Implementation` section from `$kiro-impl` or `/kiro-impl` as this step's source of truth.
+This facet defines only the adapter delta for the TAKT workflow.
+
+# Kiro Task Wave Result Collection Adapter
+
+## Kiro-specific delta
+
+Collect implementation results after TeamLeader parts finish. This is a normal parent step, not a TeamLeader part. It reads prepared worktrees and emits the wave implementation result report. It does not implement code, apply changes to the main worktree, or update `tasks.md`.
+
+## Collection rules
+
+1. Require `dispatch_mode: wave`, `wave_id`, `wave_tasks`, `task_worktree`, `task_branch`, and `_Boundary:_` from `kiro-task-wave-prepare.md`.
+2. If `kiro-task-wave-prepare.md` was summarized, recover the latest manifest entry list from a timestamped `kiro-task-wave-prepare.md.*` backup in the same Report Directory.
+3. Inspect filesystem evidence for each prepared worktree with `git -C <task_worktree> status --porcelain`, `git -C <task_worktree> diff --name-only --`, `git -C <task_worktree> ls-files --others --exclude-standard -- <boundary>`, and boundary file content checks.
+4. Treat part output as secondary evidence only. Missing or truncated part output must not cause `NEEDS_CONTEXT` when filesystem evidence proves a boundary file is ready.
+5. When available, read current run previous responses such as `context/previous_responses/execute-task-wave.*.md` and `context/previous_responses/latest.md` to recover part summaries, but do not require them when filesystem evidence is sufficient.
+6. Treat `wave_part_status: READY_FOR_REVIEW` and `wave_part_status: COMPLETE` as successful part statuses when filesystem evidence and validation evidence pass.
+7. Use the `task_branch` and `_Boundary:_` from the prepared manifest entry when part output is missing or contradictory.
+8. Emit `wave_result_refs` entries containing `selected_task`, `task_worktree`, `task_branch`, `changed_files`, `validation_evidence`, `RED_PHASE_OUTPUT`, `wave_part_status`, and `missing_context`.
+9. Return `STATUS: READY_FOR_REVIEW` when at least one prepared worktree has changed files inside its boundary and fresh validation evidence. Return `STATUS: NEEDS_CONTEXT` only when the manifest or filesystem evidence cannot be recovered. Return `STATUS: BLOCKED` only when filesystem evidence proves the task cannot proceed.
+10. Do not edit source files, task checkboxes, blocker notes, or `Implementation Notes`.
+
+## Status Report
+
+- `STATUS`: `READY_FOR_REVIEW`, `BLOCKED`, or `NEEDS_CONTEXT`.
+- `dispatch_mode`: `wave`.
+- `wave_result_refs`: collected part results. Successful entries may have `wave_part_status: READY_FOR_REVIEW` or `wave_part_status: COMPLETE`.
+- `changed_files`, `validation_evidence`, and `RED_PHASE_OUTPUT`: evidence recovered from filesystem checks and part summaries.
+
+## Output mapping
+
+Use the `kiro-implementation-result` report format. `STATUS: READY_FOR_REVIEW` with `dispatch_mode: wave` and `wave_result_refs` routes to `apply-wave-task`.

--- a/.takt/en/facets/instructions/kiro-impl-execute-task-wave.md
+++ b/.takt/en/facets/instructions/kiro-impl-execute-task-wave.md
@@ -1,0 +1,36 @@
+{extends: implement-after-tests}
+
+## Kiro Skill Source
+
+Before executing this instruction, invoke `$kiro-impl` or `/kiro-impl` and read the resolved `SKILL.md`.
+Apply the `## Step 3: Execute Implementation` section from `$kiro-impl` or `/kiro-impl` as this step's source of truth.
+Also read the `## Feature Flag Protocol` section.
+This facet defines only the adapter delta for the TAKT workflow.
+
+# Kiro TeamLeader Task Wave Execution Adapter
+
+## Kiro-specific delta
+
+Use TeamLeader only to implement prepared `(P)` tasks in isolated worktrees. Review, verify, and `tasks.md` progress updates remain in the parent one-task loop.
+
+## TeamLeader execution rules
+
+1. Require `dispatch_mode: wave`, `wave_id`, `wave_tasks`, `task_worktree`, and `task_branch` from `kiro-task-wave-prepare.md`.
+2. Decompose into exactly one TeamLeader part per wave task. Do not create extra discovery, verification, review, or progress-update parts.
+3. Each part instruction must embed the concrete `selected_task`, `task_worktree`, `task_branch`, `_Boundary:_`, and validation command hint values copied verbatim from `kiro-task-wave-prepare.md`.
+4. Do not invent wave-id-derived branch names. If the prepared manifest says `task_branch: kiro-impl/<feature>/<task-id>`, the part instruction must use that exact branch string.
+5. Each part must work only inside its assigned `task_worktree` and `task_branch`. The part must run commands with `git -C <task_worktree> ...` or absolute paths under `<task_worktree>`; it must not write the main worktree.
+6. Each part edits only files justified by its selected task `_Boundary:_` and implementation plan, resolved under the assigned `task_worktree`.
+7. For literal boundary-file tasks, create or update only the boundary file, preserve the literal required content from the task text, and validate with the manifest validation command hint. Do not run broad review or progress-update work inside the part.
+8. Each part must not update task checkboxes, blocker notes, or `Implementation Notes`.
+9. For behavioral work, each part includes `RED_PHASE_OUTPUT` before implementation evidence.
+10. Each part emits `wave_part_status`, `selected_task`, `task_worktree`, `task_branch`, `changed_files`, `validation_evidence`, `RED_PHASE_OUTPUT`, `missing_context`, and `debug_context`. Treat `READY_FOR_REVIEW` and `COMPLETE` as successful part statuses.
+11. The aggregate treats `kiro-task-wave-prepare.md` as the authoritative manifest. If that report was summarized, recover the latest manifest entry list from a timestamped `kiro-task-wave-prepare.md.*` backup before using part output.
+12. The aggregate must verify filesystem evidence for each prepared worktree with `git -C <task_worktree> status --porcelain`, `git -C <task_worktree> diff --name-only --`, and boundary file content checks. Part output is secondary evidence and must not be the only source of `changed_files` or `validation_evidence`.
+13. When part output omits a result or reports a mismatched `task_branch`, use the `task_branch` and `_Boundary:_` from the prepared manifest entry, not the part-provided value.
+14. When TeamLeader feedback asks whether more parts are needed, answer `done=true` with `parts: []` once the scheduled part ids already cover the prepared `wave_tasks`. Do not create refill, continuation, verification, or duplicate task part.
+15. The aggregate emits `wave_result_refs` for successful or blocked parts. Return `STATUS: READY_FOR_REVIEW` when at least one prepared worktree has filesystem evidence ready to apply, `STATUS: NEEDS_CONTEXT` when required task context cannot be recovered from the manifest or filesystem, and `STATUS: BLOCKED` only when no part can proceed.
+
+## Output mapping
+
+This step routes to `collect-wave-results` after TeamLeader parts complete. `collect-wave-results` writes the `kiro-implementation-result` report from worktree filesystem evidence; parent review gates run only after one wave result is applied to the main worktree.

--- a/.takt/en/facets/instructions/kiro-impl-plan-dispatch.md
+++ b/.takt/en/facets/instructions/kiro-impl-plan-dispatch.md
@@ -1,0 +1,39 @@
+{extends: plan}
+
+## Kiro Skill Source
+
+Before executing this instruction, invoke `$kiro-impl` or `/kiro-impl` and read the resolved `SKILL.md`.
+Apply the `## Step 2: Select Tasks & Determine Mode` section from `$kiro-impl` or `/kiro-impl` as this step's source of truth.
+This facet defines only the adapter delta for the TAKT workflow.
+
+# Kiro Dispatch Planning Adapter
+
+## Kiro-specific delta
+
+Choose the next execution route for `kiro-impl`: a safe `(P)` task wave, the next unapplied result from an existing wave, or the existing one task path. This step is read-only and never edits code or `tasks.md`.
+
+## Input artifacts
+
+- `.kiro/specs/<feature>/spec.json` with `ready_for_implementation`.
+- `.kiro/specs/<feature>/requirements.md`, `design.md`, and `tasks.md`.
+- Task annotations `_Boundary:_`, `_Depends:_`, numeric requirement coverage, blocker notes, checkbox state, and `(P)` markers.
+- Previous wave reports such as `kiro-task-wave-implementation-result.md`, `wave_result_refs`, `task_worktree`, and `task_branch`.
+- Pre-existing dirty files at dispatch time from `git status --porcelain`.
+
+## Dispatch rules
+
+1. Stop before edit if `ready_for_implementation` is not true, approvals are incomplete, or required artifacts are missing.
+2. If there are unapplied successful wave results for unchecked tasks, return `dispatch_mode: wave_apply` with `wave_result_refs`.
+3. Otherwise find the first eligible `(P)` wave with two unchecked executable leaf tasks. If more than two peer tasks are eligible, emit only the first two as this wave and leave the rest for a later `plan-dispatch` pass.
+4. A task is wave-eligible only when `_Depends:_ none`, `_Boundary:_` is present, requirement numbers are present, blocker notes do not stop execution, and its boundary does not overlap any peer in `wave_tasks`.
+5. Record `baseline_dirty_files` and exclude them from the selected task diff.
+6. Return `dispatch_mode: wave` with `wave_id` and `wave_tasks` only when the wave is safe for TeamLeader execution.
+7. Return `dispatch_mode: single` when no safe `(P)` wave exists; the next step will use `plan-one-task`.
+8. Return `STATUS: BLOCKED` with `selected_task` and `blocker_note_required: true` only for a concrete selected task blocker. Readiness-level blockers use no `selected_task`.
+
+## Output mapping
+
+- `STATUS: READY_FOR_REVIEW` with `dispatch_mode: wave` routes to `prepare-task-wave`.
+- `STATUS: READY_FOR_REVIEW` with `dispatch_mode: wave_apply` routes to `apply-wave-task`.
+- `STATUS: READY_FOR_REVIEW` with `dispatch_mode: single` routes to `plan-one-task`.
+- `STATUS: BLOCKED` and `STATUS: NEEDS_CONTEXT` use the existing blocker rules.

--- a/.takt/en/facets/instructions/kiro-impl-prepare-task-wave.md
+++ b/.takt/en/facets/instructions/kiro-impl-prepare-task-wave.md
@@ -1,0 +1,32 @@
+{extends: fix}
+
+## Kiro Skill Source
+
+Before executing this instruction, invoke `$kiro-impl` or `/kiro-impl` and read the resolved `SKILL.md`.
+Apply the `## Step 3: Execute Implementation` section from `$kiro-impl` or `/kiro-impl` as this step's source of truth.
+This facet defines only the adapter delta for the TAKT workflow.
+
+# Kiro Task Wave Preparation Adapter
+
+## Kiro-specific delta
+
+Prepare isolated git worktrees for a planned `(P)` task wave. This step creates only wave isolation state; it does not implement code and does not update `tasks.md`.
+
+This step needs host-level git metadata writes because `git branch` and `git worktree add` create refs under `.git`. The workflow step must run with `required_permission_mode: full`; implementation parts remain `edit`.
+
+## Preparation rules
+
+1. Require `dispatch_mode: wave`, `wave_id`, and `wave_tasks` from `kiro-implementation-dispatch.md`.
+2. For each wave task, create an isolated worktree under `.takt/worktrees/kiro-impl/<feature>/<task-id>/`.
+3. Create or use the matching branch name `kiro-impl/<feature>/<task-id>` only for that `task_worktree`.
+4. Stop with `STATUS: BLOCKED` if the branch or worktree already exists with unknown contents, if the base revision is ambiguous, or if a task lacks `_Boundary:_` or `_Depends:_ none`.
+5. Preserve `baseline_dirty_files`; do not include them in any selected task diff.
+6. Emit one manifest entry per task containing `selected_task`, `task_worktree`, `task_branch`, `_Boundary:_`, and validation command hints.
+7. Preserve the manifest entry list in the final report `wave_tasks`; do not replace it with a validation summary or a worktree-only list.
+8. Do not edit source files, task checkboxes, blocker notes, or `Implementation Notes`.
+
+## Output mapping
+
+- `STATUS: READY_FOR_REVIEW` with `dispatch_mode: wave`, `wave_tasks`, and `wave_worktrees prepared` routes to `execute-task-wave`.
+- `STATUS: BLOCKED` with `selected_task` and `blocker_note_required: true` routes to progress/blocker handling.
+- Other `STATUS: BLOCKED` or `STATUS: NEEDS_CONTEXT` stops the wave before TeamLeader execution.

--- a/.takt/en/facets/instructions/kiro-spec-requirements-review.md
+++ b/.takt/en/facets/instructions/kiro-spec-requirements-review.md
@@ -1,4 +1,4 @@
-{extends: review-requirements}
+{extends: review-pure}
 
 ## Kiro Skill Source
 

--- a/.takt/en/facets/instructions/kiro-spec-requirements.md
+++ b/.takt/en/facets/instructions/kiro-spec-requirements.md
@@ -1,4 +1,4 @@
-{extends: review-requirements}
+{extends: review-pure}
 
 ## Kiro Skill Source
 

--- a/.takt/en/facets/instructions/kiro-spec-tasks-review.md
+++ b/.takt/en/facets/instructions/kiro-spec-tasks-review.md
@@ -1,4 +1,4 @@
-{extends: review-requirements}
+{extends: review-pure}
 
 ## Kiro Skill Source
 

--- a/.takt/en/facets/output-contracts/kiro-implementation-result.md
+++ b/.takt/en/facets/output-contracts/kiro-implementation-result.md
@@ -13,6 +13,14 @@ Full custom reason: N/A; this facet extends the built-in validation output contr
 - `implementation_plan`: selected task boundary, dependencies, requirement coverage, file scope, and validation commands.
 - `baseline_dirty_files`: pre-existing dirty files captured during planning; these are not part of the selected task diff.
 - `task_set_status`: one of `ALL_TASKS_COMPLETE`, `REMAINING_TASKS_EXIST`, or `N/A`; derived from executable leaf task checkboxes only, not group header checkboxes.
+- `dispatch_mode`: one of `single`, `wave`, `wave_apply`, or `N/A`; selects the normal one-task path, TeamLeader wave path, or wave-result apply path.
+- `wave_id`: stable identifier for a `(P)` task wave, or `N/A`.
+- `wave_tasks`: selected `(P)` executable leaf tasks for a TeamLeader wave, including `_Boundary:_`, `_Depends:_`, `task_worktree`, and `task_branch` when prepared.
+- `wave_worktrees`: preparation status for isolated worktrees, or `N/A`.
+- `wave_result_refs`: references to TeamLeader part results that are ready, blocked, or still pending application.
+- `wave_part_status`: per-part result status for a TeamLeader wave task, such as `READY_FOR_REVIEW`, `COMPLETE`, `BLOCKED`, or `NEEDS_CONTEXT`.
+- `task_worktree`: isolated worktree path for a wave task, or `N/A` on the normal one-task path.
+- `task_branch`: isolated branch for a wave task, or `N/A` on the normal one-task path.
 - `changed_files`: files edited for the selected task.
 - `validation_evidence`: commands, exit codes, and fresh outputs.
 - `RED_PHASE_OUTPUT`: failing test evidence for behavioral tasks, or `N/A`.
@@ -24,3 +32,7 @@ Full custom reason: N/A; this facet extends the built-in validation output contr
 ## Branching Rule
 
 Workflow rules branch on `STATUS` plus the documented machine fields above; `summary` is never used for routing.
+
+## Report Preservation
+
+This contract describes an implementation result, not a validation review. Report generation must preserve the step's implementation machine fields and must not rewrite them as `APPROVE`, `REJECT`, `Final Validation Result`, or finding tables unless the step explicitly produced that shape. When the step response already contains `STATUS`, `dispatch_mode`, `wave_result_refs`, `changed_files`, or `validation_evidence`, carry those fields into the report instead of re-judging them.

--- a/.takt/en/workflows/kiro-impl.yaml
+++ b/.takt/en/workflows/kiro-impl.yaml
@@ -1,5 +1,5 @@
 name: kiro-impl
-description: Kiro - Implement eligible tasks from an approved spec one at a time, repeating review, debug, verify, and progress updates until all tasks complete
+description: Kiro - Implement eligible tasks from an approved spec, using TeamLeader only for safe (P) task waves and otherwise preserving the one-task review loop
 workflow_config:
   provider_options:
     codex:
@@ -7,9 +7,14 @@ workflow_config:
     opencode:
       network_access: true
 max_steps: 200
-initial_step: plan-one-task
+initial_step: plan-dispatch
 
 instructions:
+  kiro-impl-plan-dispatch: ../facets/instructions/kiro-impl-plan-dispatch.md
+  kiro-impl-prepare-task-wave: ../facets/instructions/kiro-impl-prepare-task-wave.md
+  kiro-impl-execute-task-wave: ../facets/instructions/kiro-impl-execute-task-wave.md
+  kiro-impl-collect-wave-results: ../facets/instructions/kiro-impl-collect-wave-results.md
+  kiro-impl-apply-wave-task: ../facets/instructions/kiro-impl-apply-wave-task.md
   kiro-impl-plan-one-task: ../facets/instructions/kiro-impl-plan-one-task.md
   kiro-impl-execute-task: ../facets/instructions/kiro-impl-execute-task.md
   kiro-impl-update-progress: ../facets/instructions/kiro-impl-update-progress.md
@@ -65,6 +70,188 @@ loop_monitors:
           next: update-progress
 
 steps:
+  - name: plan-dispatch
+    edit: false
+    persona: planner
+    policy:
+      - kiro-artifact-operations
+      - kiro-spec-lifecycle
+      - kiro-spec-task-annotations
+      - kiro-impl-task-progress
+    session: refresh
+    knowledge:
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Bash
+    required_permission_mode: readonly
+    pass_previous_response: false
+    instruction: kiro-impl-plan-dispatch
+    output_contracts:
+      report:
+        - name: kiro-implementation-dispatch.md
+          format: kiro-implementation-result
+    rules:
+      - condition: STATUS READY_FOR_REVIEW and dispatch_mode wave and wave_tasks emitted
+        next: prepare-task-wave
+      - condition: STATUS READY_FOR_REVIEW and dispatch_mode wave_apply and wave_result_refs emitted
+        next: apply-wave-task
+      - condition: STATUS READY_FOR_REVIEW and dispatch_mode single
+        next: plan-one-task
+      - condition: STATUS BLOCKED and selected task exists and blocker_note_required true
+        next: update-progress
+      - condition: STATUS BLOCKED and no selected task or readiness gate failed
+        next: ABORT
+      - condition: STATUS NEEDS_CONTEXT
+        next: ABORT
+
+  - name: prepare-task-wave
+    edit: true
+    persona: coder
+    policy:
+      - kiro-artifact-operations
+      - kiro-spec-task-annotations
+      - kiro-impl-task-progress
+    session: refresh
+    knowledge:
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+    required_permission_mode: full
+    instruction: kiro-impl-prepare-task-wave
+    output_contracts:
+      report:
+        - name: kiro-task-wave-prepare.md
+          format: kiro-implementation-result
+    rules:
+      - condition: STATUS READY_FOR_REVIEW and dispatch_mode wave and wave_tasks emitted and wave_worktrees prepared
+        next: execute-task-wave
+      - condition: STATUS BLOCKED and selected task exists and blocker_note_required true
+        next: update-progress
+      - condition: STATUS BLOCKED
+        next: ABORT
+      - condition: STATUS NEEDS_CONTEXT
+        next: ABORT
+
+  - name: execute-task-wave
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+      - kiro-artifact-operations
+      - kiro-impl-task-progress
+    session: refresh
+    knowledge:
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+    required_permission_mode: edit
+    team_leader:
+      max_parts: 2
+      refill_threshold: 0
+      timeout_ms: 1200000
+      part_persona: coder
+      part_edit: true
+      part_permission_mode: edit
+      part_allowed_tools:
+        - Read
+        - Glob
+        - Grep
+        - Edit
+        - Write
+        - Bash
+    instruction: kiro-impl-execute-task-wave
+    rules:
+      - condition: "true"
+        next: collect-wave-results
+
+  - name: collect-wave-results
+    edit: false
+    persona: coder
+    policy:
+      - testing
+      - kiro-artifact-operations
+      - kiro-impl-task-progress
+    session: refresh
+    knowledge:
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Bash
+    required_permission_mode: readonly
+    pass_previous_response: false
+    instruction: kiro-impl-collect-wave-results
+    output_contracts:
+      report:
+        - name: kiro-task-wave-implementation-result.md
+          format: kiro-implementation-result
+    rules:
+      - condition: STATUS READY_FOR_REVIEW and dispatch_mode wave and wave_result_refs emitted
+        next: apply-wave-task
+      - condition: STATUS BLOCKED and selected task exists and blocker_note_required true
+        next: update-progress
+      - condition: STATUS BLOCKED
+        next: ABORT
+      - condition: STATUS NEEDS_CONTEXT
+        next: ABORT
+
+  - name: apply-wave-task
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+      - kiro-artifact-operations
+      - kiro-impl-task-progress
+    session: refresh
+    knowledge:
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+    required_permission_mode: edit
+    instruction: kiro-impl-apply-wave-task
+    output_contracts:
+      report:
+        - name: kiro-task-implementation-result.md
+          format: kiro-implementation-result
+    rules:
+      - condition: STATUS READY_FOR_REVIEW and selected task exists
+        next: ai-quality-gate
+      - condition: STATUS BLOCKED
+        next: debug-task
+      - condition: STATUS NEEDS_CONTEXT
+        next: debug-task
+
   - name: plan-one-task
     edit: false
     persona: planner
@@ -355,7 +542,7 @@ steps:
       - condition: STATUS READY_FOR_REVIEW and selected task checkbox updated and task_set_status ALL_TASKS_COMPLETE
         next: validate-impl-final
       - condition: STATUS READY_FOR_REVIEW and selected task checkbox updated and task_set_status REMAINING_TASKS_EXIST
-        next: plan-one-task
+        next: plan-dispatch
       - condition: STATUS BLOCKED and selected task blocker note written
         next: ABORT
       - condition: STATUS BLOCKED and progress update could not be written safely

--- a/.takt/ja/facets/instructions/kiro-impl-apply-wave-task.md
+++ b/.takt/ja/facets/instructions/kiro-impl-apply-wave-task.md
@@ -1,0 +1,40 @@
+{extends: implement-after-tests}
+
+## Kiro Skill Source
+
+この instruction を実行する前に、`$kiro-impl` または `/kiro-impl` を呼び出し、解決された `SKILL.md` を読む。
+`$kiro-impl` または `/kiro-impl` の `## Step 3: Execute Implementation` section をこの step の source of truth として適用する。
+追加で `## Feature Flag Protocol` section も読む。
+この facet は TAKT workflow への adapter delta だけを定義する。
+
+# Kiro Wave Result Apply Adapter
+
+## Kiro 固有差分
+
+readyなwave resultをexactly oneだけmain worktreeへ適用し、既存のselected-task quality gatesでreviewできる状態にする。このstepはTeamLeader part resultを通常の `kiro-task-implementation-result.md` contractへ戻す。
+
+## Apply rules
+
+1. `dispatch_mode: wave_apply`、または `wave_result_refs` を持つfreshな `dispatch_mode: wave` aggregateを必須にする。
+2. `tasks.md` でまだuncheckedな `selected_task` を持つ最初のsuccessful `wave_part_status`（`READY_FOR_REVIEW` または `COMPLETE`）を選ぶ。
+3. 適用直前に `tasks.md`、`task_worktree`、`task_branch`、`baseline_dirty_files` をre-readする。
+4. そのselected taskのdiffだけを `task_branch` からmain worktreeへapplyまたはmergeする。
+5. main worktreeが `baseline_dirty_files` 以外で変わっている、task checkboxがuncheckedでない、branch conflictがある、または `changed_files` が `_Boundary:_` を超える場合は `STATUS: BLOCKED` で止める。
+6. `RED_PHASE_OUTPUT`、`validation_evidence`、`changed_files`、`task_worktree`、`task_branch`、`wave_id`、`wave_result_refs` をparent resultへ保持する。
+7. task checkboxes、blocker notes、`Implementation Notes` は更新しない。既存のreview、verify、progress stepsがそれらのgateを担当する。
+
+## Status Report
+
+- `STATUS`: `READY_FOR_REVIEW`、`BLOCKED`、`NEEDS_CONTEXT` のいずれか。
+- `dispatch_mode`: `wave_apply`。
+- `selected_task`: main worktreeへ適用したsingle task。
+- `baseline_dirty_files`: dispatch時点の既存未コミットfiles。
+- `changed_files`: selected task boundary内で変更したfiles。
+- `validation_evidence`: wave partのcommands、exit codes、fresh results、およびapply-time checks。
+- `RED_PHASE_OUTPUT`: behavioral tasksでは必須、それ以外は `N/A`。
+- `task_worktree` と `task_branch`: applied partのsource isolation state。
+- `wave_result_refs`: remaining readyまたはblocked wave results。
+
+## Output mapping
+
+`kiro-implementation-result` formatで `kiro-task-implementation-result.md` を出力する。`STATUS: READY_FOR_REVIEW` は `ai-quality-gate` へ進み、failureは `debug-task` へ進んでselected taskを通常のsingle-task repairへfallbackできるようにする。

--- a/.takt/ja/facets/instructions/kiro-impl-collect-wave-results.md
+++ b/.takt/ja/facets/instructions/kiro-impl-collect-wave-results.md
@@ -1,0 +1,37 @@
+{extends: implement-after-tests}
+
+## Kiro Skill Source
+
+この instruction を実行する前に、`$kiro-impl` または `/kiro-impl` を呼び出し、解決された `SKILL.md` を読む。
+`$kiro-impl` または `/kiro-impl` の `## Step 3: Execute Implementation` section をこの step の source of truth として適用する。
+この facet は TAKT workflow への adapter delta だけを定義する。
+
+# Kiro Task Wave Result Collection Adapter
+
+## Kiro 固有差分
+
+TeamLeader part 完了後に実装結果を収集する。この step は通常の parent step であり、TeamLeader part ではない。prepared worktrees を読み、wave implementation result report を出力する。code implementation、main worktree へのapply、`tasks.md` 更新は行わない。
+
+## Collection rules
+
+1. `kiro-task-wave-prepare.md` から `dispatch_mode: wave`、`wave_id`、`wave_tasks`、`task_worktree`、`task_branch`、`_Boundary:_` を必須にする。
+2. `kiro-task-wave-prepare.md` がsummary化されている場合は、同じ Report Directory のtimestamp付き `kiro-task-wave-prepare.md.*` backupから最新のmanifest entry listを復元する。
+3. 各prepared worktreeについて `git -C <task_worktree> status --porcelain`、`git -C <task_worktree> diff --name-only --`、`git -C <task_worktree> ls-files --others --exclude-standard -- <boundary>`、boundary file content checksでfilesystem evidenceを検査する。
+4. part outputはsecondary evidenceとしてだけ扱う。filesystem evidence がboundary fileのready状態を証明する場合、part outputの欠落やtruncationだけで `NEEDS_CONTEXT` にしてはならない。
+5. 利用可能な場合は、current run の `context/previous_responses/execute-task-wave.*.md` と `context/previous_responses/latest.md` を読み、part summaries を復元する。ただし filesystem evidence が十分な場合は必須にしない。
+6. filesystem evidence と validation evidence が通っている場合、`wave_part_status: READY_FOR_REVIEW` と `wave_part_status: COMPLETE` の両方を successful part status として扱う。
+7. part outputが欠落または矛盾する場合は、prepared manifest entry の `task_branch` と `_Boundary:_` を使う。
+8. `wave_result_refs` entriesには `selected_task`、`task_worktree`、`task_branch`、`changed_files`、`validation_evidence`、`RED_PHASE_OUTPUT`、`wave_part_status`、`missing_context` を含める。
+9. 少なくとも1つのprepared worktreeにboundary内のchanged filesとfresh validation evidenceがあれば `STATUS: READY_FOR_REVIEW` を返す。manifestまたはfilesystem evidenceを復元できない場合だけ `STATUS: NEEDS_CONTEXT` を返す。filesystem evidenceによりtaskが進めないと証明できる場合だけ `STATUS: BLOCKED` を返す。
+10. source files、task checkboxes、blocker notes、`Implementation Notes` は編集しない。
+
+## Status Report
+
+- `STATUS`: `READY_FOR_REVIEW`、`BLOCKED`、`NEEDS_CONTEXT` のいずれか。
+- `dispatch_mode`: `wave`。
+- `wave_result_refs`: 収集したpart results。successful entry は `wave_part_status: READY_FOR_REVIEW` または `wave_part_status: COMPLETE` を持てる。
+- `changed_files`、`validation_evidence`、`RED_PHASE_OUTPUT`: filesystem checks と part summaries から復元した証跡。
+
+## Output mapping
+
+`kiro-implementation-result` report formatを使う。`dispatch_mode: wave` と `wave_result_refs` を持つ `STATUS: READY_FOR_REVIEW` は `apply-wave-task` へ進む。

--- a/.takt/ja/facets/instructions/kiro-impl-execute-task-wave.md
+++ b/.takt/ja/facets/instructions/kiro-impl-execute-task-wave.md
@@ -1,0 +1,36 @@
+{extends: implement-after-tests}
+
+## Kiro Skill Source
+
+この instruction を実行する前に、`$kiro-impl` または `/kiro-impl` を呼び出し、解決された `SKILL.md` を読む。
+`$kiro-impl` または `/kiro-impl` の `## Step 3: Execute Implementation` section をこの step の source of truth として適用する。
+追加で `## Feature Flag Protocol` section も読む。
+この facet は TAKT workflow への adapter delta だけを定義する。
+
+# Kiro TeamLeader Task Wave Execution Adapter
+
+## Kiro 固有差分
+
+TeamLeader は prepared `(P)` tasks を isolated worktrees で実装する場合だけ使う。review、verify、`tasks.md` progress updates はparentの one-task loop に残す。
+
+## TeamLeader execution rules
+
+1. `kiro-task-wave-prepare.md` から `dispatch_mode: wave`、`wave_id`、`wave_tasks`、`task_worktree`、`task_branch` を必須にする。
+2. wave taskごとにexactly one TeamLeader partへ分解する。追加のdiscovery、verification、review、progress-update partを作らない。
+3. 各part instructionには、`kiro-task-wave-prepare.md` から具体的な `selected_task`、`task_worktree`、`task_branch`、`_Boundary:_`、validation command hintをverbatimにコピーして必ず埋め込む。
+4. Do not invent wave-id-derived branch names. wave_id由来のbranch名を作らない。prepared manifestが `task_branch: kiro-impl/<feature>/<task-id>` を示す場合、part instructionはそのbranch文字列をそのまま使う。
+5. 各partは割り当てられた `task_worktree` と `task_branch` の内側だけで作業する。partは `git -C <task_worktree> ...` または `<task_worktree>` 配下の絶対pathを使い、main worktreeへ書き込まない。
+6. 各partはselected taskの `_Boundary:_` とimplementation planで正当化されるfileだけを、割り当てられた `task_worktree` 配下で編集する。
+7. literal boundary-file taskでは、boundary fileだけを作成または更新し、task textのliteral required contentを保持し、manifestのvalidation command hintで検証する。part内で広いreviewやprogress-update作業をしない。
+8. 各partはtask checkboxes、blocker notes、`Implementation Notes` を更新しない。
+9. behavioral workではimplementation evidenceの前に `RED_PHASE_OUTPUT` を含める。
+10. 各partは `wave_part_status`、`selected_task`、`task_worktree`、`task_branch`、`changed_files`、`validation_evidence`、`RED_PHASE_OUTPUT`、`missing_context`、`debug_context` を出力する。`READY_FOR_REVIEW` と `COMPLETE` は successful part status として扱う。
+11. aggregateは `kiro-task-wave-prepare.md` をauthoritative manifestとして扱う。そのreportがsummary化されている場合は、part outputを使う前にtimestamp付きの `kiro-task-wave-prepare.md.*` backupから最新のmanifest entry listを復元する。
+12. aggregateは各prepared worktreeについて `git -C <task_worktree> status --porcelain`、`git -C <task_worktree> diff --name-only --`、boundary file content checksでfilesystem evidenceを検証する。part outputはsecondary evidenceであり、`changed_files` や `validation_evidence` の唯一の根拠にしてはならない。
+13. part outputがresultを省略した場合、または `task_branch` がmanifestと不一致の場合は、part-provided valueではなくprepared manifest entryの `task_branch` と `_Boundary:_` を使う。
+14. TeamLeader feedbackが追加partの要否を尋ねる場合、scheduled part ids がprepared `wave_tasks` をすでにcoverしているなら `done=true` と `parts: []` を返す。refill、continuation、verification、duplicate task partを作らない。
+15. aggregateはsuccessfulまたはblocked partの `wave_result_refs` を出力する。少なくとも1つのprepared worktreeにapply可能なfilesystem evidenceがあれば `STATUS: READY_FOR_REVIEW`、manifestまたはfilesystemからrequired task contextを復元できない場合は `STATUS: NEEDS_CONTEXT`、どのpartも進めない場合だけ `STATUS: BLOCKED` を返す。
+
+## Output mapping
+
+このstepはTeamLeader parts完了後に `collect-wave-results` へ進む。`collect-wave-results` がworktree filesystem evidenceから `kiro-implementation-result` reportを書く。parent review gatesは、1つのwave resultがmain worktreeへ適用された後だけ実行する。

--- a/.takt/ja/facets/instructions/kiro-impl-plan-dispatch.md
+++ b/.takt/ja/facets/instructions/kiro-impl-plan-dispatch.md
@@ -1,0 +1,39 @@
+{extends: plan}
+
+## Kiro Skill Source
+
+この instruction を実行する前に、`$kiro-impl` または `/kiro-impl` を呼び出し、解決された `SKILL.md` を読む。
+`$kiro-impl` または `/kiro-impl` の `## Step 2: Select Tasks & Determine Mode` section をこの step の source of truth として適用する。
+この facet は TAKT workflow への adapter delta だけを定義する。
+
+# Kiro Dispatch Planning Adapter
+
+## Kiro 固有差分
+
+`kiro-impl` の次の実行経路を選ぶ。safe な `(P)` task wave、既存 wave の未適用 result、または既存の one task path のいずれかに分岐する。この step は read-only で、code も `tasks.md` も編集しない。
+
+## Input artifacts
+
+- `ready_for_implementation` を持つ `.kiro/specs/<feature>/spec.json`。
+- `.kiro/specs/<feature>/requirements.md`、`design.md`、`tasks.md`。
+- task annotation の `_Boundary:_`、`_Depends:_`、numeric requirement coverage、blocker notes、checkbox state、`(P)` markers。
+- `kiro-task-wave-implementation-result.md`、`wave_result_refs`、`task_worktree`、`task_branch` などの previous wave reports。
+- `git status --porcelain` による dispatch 時点の既存未コミット files。
+
+## Dispatch rules
+
+1. `ready_for_implementation` がtrueでない、approvalが不足する、required artifactsが欠ける場合はedit前に停止する。
+2. unchecked task向けの未適用successful wave resultがある場合は、`wave_result_refs` を含めて `dispatch_mode: wave_apply` を返す。
+3. それ以外では、unchecked executable leaf taskが2件ある最初のeligible `(P)` waveを探す。eligible peer taskが3件以上ある場合も、このwaveでは先頭2件（first two）だけを出力し、残りは後続の `plan-dispatch` に残す。
+4. wave-eligible taskは `_Depends:_ none`、`_Boundary:_`、requirement numbersを持ち、blocker notesが実行を止めず、`wave_tasks` 内のpeerとboundaryが重ならない場合だけ対象にする。
+5. `baseline_dirty_files` を記録し、selected task diffから除外する。
+6. TeamLeader executionに安全な場合だけ、`wave_id` と `wave_tasks` を含めて `dispatch_mode: wave` を返す。
+7. safeな `(P)` wave がない場合は `dispatch_mode: single` を返す。次stepは `plan-one-task` を使う。
+8. concrete selected task blockerの場合だけ `selected_task` と `blocker_note_required: true` を含めて `STATUS: BLOCKED` を返す。readiness-level blockerでは `selected_task` を使わない。
+
+## Output mapping
+
+- `dispatch_mode: wave` を持つ `STATUS: READY_FOR_REVIEW` は `prepare-task-wave` へ進む。
+- `dispatch_mode: wave_apply` を持つ `STATUS: READY_FOR_REVIEW` は `apply-wave-task` へ進む。
+- `dispatch_mode: single` を持つ `STATUS: READY_FOR_REVIEW` は `plan-one-task` へ進む。
+- `STATUS: BLOCKED` と `STATUS: NEEDS_CONTEXT` は既存のblocker rulesに従う。

--- a/.takt/ja/facets/instructions/kiro-impl-prepare-task-wave.md
+++ b/.takt/ja/facets/instructions/kiro-impl-prepare-task-wave.md
@@ -1,0 +1,32 @@
+{extends: fix}
+
+## Kiro Skill Source
+
+この instruction を実行する前に、`$kiro-impl` または `/kiro-impl` を呼び出し、解決された `SKILL.md` を読む。
+`$kiro-impl` または `/kiro-impl` の `## Step 3: Execute Implementation` section をこの step の source of truth として適用する。
+この facet は TAKT workflow への adapter delta だけを定義する。
+
+# Kiro Task Wave Preparation Adapter
+
+## Kiro 固有差分
+
+計画済み `(P)` task wave のために isolated git worktrees を準備する。この step は wave isolation state だけを作成し、code implementationも `tasks.md` 更新も行わない。
+
+この step は `git branch` と `git worktree add` によって `.git` 配下の ref を作成するため、host-level の git metadata write が必要。workflow step は `required_permission_mode: full` で実行し、implementation part は `edit` のままにする。
+
+## Preparation rules
+
+1. `kiro-implementation-dispatch.md` から `dispatch_mode: wave`、`wave_id`、`wave_tasks` を必須にする。
+2. 各wave taskごとに `.takt/worktrees/kiro-impl/<feature>/<task-id>/` 配下の isolated worktree を作る。
+3. 対応する `task_worktree` 専用に、branch name `kiro-impl/<feature>/<task-id>` を作成または使用する。
+4. branchまたはworktreeがunknown contentsで既に存在する、base revisionが曖昧、taskに `_Boundary:_` または `_Depends:_ none` がない場合は `STATUS: BLOCKED` で止める。
+5. `baseline_dirty_files` を保持し、selected task diffには含めない。
+6. taskごとに `selected_task`、`task_worktree`、`task_branch`、`_Boundary:_`、validation command hintsを持つmanifest entryを出力する。
+7. final report の `wave_tasks` に manifest entry list を保持し、validation summary やworktree-only listで置き換えない。
+8. source files、task checkboxes、blocker notes、`Implementation Notes` は編集しない。
+
+## Output mapping
+
+- `dispatch_mode: wave`、`wave_tasks`、`wave_worktrees prepared` を持つ `STATUS: READY_FOR_REVIEW` は `execute-task-wave` へ進む。
+- `selected_task` と `blocker_note_required: true` を持つ `STATUS: BLOCKED` はprogress/blocker handlingへ進む。
+- それ以外の `STATUS: BLOCKED` または `STATUS: NEEDS_CONTEXT` はTeamLeader execution前にwaveを停止する。

--- a/.takt/ja/facets/instructions/kiro-spec-requirements-review.md
+++ b/.takt/ja/facets/instructions/kiro-spec-requirements-review.md
@@ -1,4 +1,4 @@
-{extends: review-requirements}
+{extends: review-pure}
 
 ## Kiro Skill Source
 

--- a/.takt/ja/facets/instructions/kiro-spec-requirements.md
+++ b/.takt/ja/facets/instructions/kiro-spec-requirements.md
@@ -1,4 +1,4 @@
-{extends: review-requirements}
+{extends: review-pure}
 
 ## Kiro Skill Source
 

--- a/.takt/ja/facets/instructions/kiro-spec-tasks-review.md
+++ b/.takt/ja/facets/instructions/kiro-spec-tasks-review.md
@@ -1,4 +1,4 @@
-{extends: review-requirements}
+{extends: review-pure}
 
 ## Kiro Skill Source
 

--- a/.takt/ja/facets/output-contracts/kiro-implementation-result.md
+++ b/.takt/ja/facets/output-contracts/kiro-implementation-result.md
@@ -13,6 +13,14 @@ Full custom reason: N/A; this facet extends the built-in validation output contr
 - `implementation_plan`: selected taskのboundary、dependencies、requirement coverage、file scope、validation commands。
 - `baseline_dirty_files`: planning時点の既存未コミットfiles。selected task diffの一部ではない。
 - `task_set_status`: `ALL_TASKS_COMPLETE`、`REMAINING_TASKS_EXIST`、`N/A` のいずれか。executable leaf task checkboxだけから導出し、group header checkboxは含めない。
+- `dispatch_mode`: `single`、`wave`、`wave_apply`、`N/A` のいずれか。normal one-task path、TeamLeader wave path、wave-result apply pathを選ぶ。
+- `wave_id`: `(P)` task waveのstable identifier。該当しない場合は `N/A`。
+- `wave_tasks`: TeamLeader waveで選択した `(P)` executable leaf tasks。準備後は `_Boundary:_`、`_Depends:_`、`task_worktree`、`task_branch` を含める。
+- `wave_worktrees`: isolated worktrees のpreparation status。該当しない場合は `N/A`。
+- `wave_result_refs`: ready、blocked、または未適用のTeamLeader part resultsへのreferences。
+- `wave_part_status`: TeamLeader wave taskごとのpart result status。例: `READY_FOR_REVIEW`、`COMPLETE`、`BLOCKED`、`NEEDS_CONTEXT`。
+- `task_worktree`: wave taskのisolated worktree path。normal one-task pathでは `N/A`。
+- `task_branch`: wave taskのisolated branch。normal one-task pathでは `N/A`。
 - `changed_files`: selected taskで編集したfiles。
 - `validation_evidence`: commands、exit codes、fresh outputs。
 - `RED_PHASE_OUTPUT`: behavioral tasksのfailing test evidence、または `N/A`。
@@ -24,3 +32,7 @@ Full custom reason: N/A; this facet extends the built-in validation output contr
 ## Branching Rule
 
 workflow rulesは `STATUS` と上記machine fieldsで分岐する。`summary` はroutingに使わない。
+
+## Report Preservation
+
+この contract はimplementation resultを表すものであり、validation reviewではない。Report generation はstepのimplementation machine fieldsを保持し、stepが明示的にその形を出していない限り、`APPROVE`、`REJECT`、`Final Validation Result`、finding tablesへ書き換えない。step responseに `STATUS`、`dispatch_mode`、`wave_result_refs`、`changed_files`、`validation_evidence` が含まれる場合は、再判定せずreportへ引き継ぐ。

--- a/.takt/ja/workflows/kiro-impl.yaml
+++ b/.takt/ja/workflows/kiro-impl.yaml
@@ -1,5 +1,5 @@
 name: kiro-impl
-description: Kiro - approved spec から eligible な task を 1 つずつ実装し、全 task 完了まで review、debug、verify、progress update を反復する
+description: Kiro - approved spec から eligible な task を実装する。(P) task wave のときだけ TeamLeader を使い、それ以外は one-task review loop を維持する
 workflow_config:
   provider_options:
     codex:
@@ -7,9 +7,14 @@ workflow_config:
     opencode:
       network_access: true
 max_steps: 200
-initial_step: plan-one-task
+initial_step: plan-dispatch
 
 instructions:
+  kiro-impl-plan-dispatch: ../facets/instructions/kiro-impl-plan-dispatch.md
+  kiro-impl-prepare-task-wave: ../facets/instructions/kiro-impl-prepare-task-wave.md
+  kiro-impl-execute-task-wave: ../facets/instructions/kiro-impl-execute-task-wave.md
+  kiro-impl-collect-wave-results: ../facets/instructions/kiro-impl-collect-wave-results.md
+  kiro-impl-apply-wave-task: ../facets/instructions/kiro-impl-apply-wave-task.md
   kiro-impl-plan-one-task: ../facets/instructions/kiro-impl-plan-one-task.md
   kiro-impl-execute-task: ../facets/instructions/kiro-impl-execute-task.md
   kiro-impl-update-progress: ../facets/instructions/kiro-impl-update-progress.md
@@ -65,6 +70,188 @@ loop_monitors:
           next: update-progress
 
 steps:
+  - name: plan-dispatch
+    edit: false
+    persona: planner
+    policy:
+      - kiro-artifact-operations
+      - kiro-spec-lifecycle
+      - kiro-spec-task-annotations
+      - kiro-impl-task-progress
+    session: refresh
+    knowledge:
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Bash
+    required_permission_mode: readonly
+    pass_previous_response: false
+    instruction: kiro-impl-plan-dispatch
+    output_contracts:
+      report:
+        - name: kiro-implementation-dispatch.md
+          format: kiro-implementation-result
+    rules:
+      - condition: STATUS READY_FOR_REVIEW and dispatch_mode wave and wave_tasks emitted
+        next: prepare-task-wave
+      - condition: STATUS READY_FOR_REVIEW and dispatch_mode wave_apply and wave_result_refs emitted
+        next: apply-wave-task
+      - condition: STATUS READY_FOR_REVIEW and dispatch_mode single
+        next: plan-one-task
+      - condition: STATUS BLOCKED and selected task exists and blocker_note_required true
+        next: update-progress
+      - condition: STATUS BLOCKED and no selected task or readiness gate failed
+        next: ABORT
+      - condition: STATUS NEEDS_CONTEXT
+        next: ABORT
+
+  - name: prepare-task-wave
+    edit: true
+    persona: coder
+    policy:
+      - kiro-artifact-operations
+      - kiro-spec-task-annotations
+      - kiro-impl-task-progress
+    session: refresh
+    knowledge:
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+    required_permission_mode: full
+    instruction: kiro-impl-prepare-task-wave
+    output_contracts:
+      report:
+        - name: kiro-task-wave-prepare.md
+          format: kiro-implementation-result
+    rules:
+      - condition: STATUS READY_FOR_REVIEW and dispatch_mode wave and wave_tasks emitted and wave_worktrees prepared
+        next: execute-task-wave
+      - condition: STATUS BLOCKED and selected task exists and blocker_note_required true
+        next: update-progress
+      - condition: STATUS BLOCKED
+        next: ABORT
+      - condition: STATUS NEEDS_CONTEXT
+        next: ABORT
+
+  - name: execute-task-wave
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+      - kiro-artifact-operations
+      - kiro-impl-task-progress
+    session: refresh
+    knowledge:
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+    required_permission_mode: edit
+    team_leader:
+      max_parts: 2
+      refill_threshold: 0
+      timeout_ms: 1200000
+      part_persona: coder
+      part_edit: true
+      part_permission_mode: edit
+      part_allowed_tools:
+        - Read
+        - Glob
+        - Grep
+        - Edit
+        - Write
+        - Bash
+    instruction: kiro-impl-execute-task-wave
+    rules:
+      - condition: "true"
+        next: collect-wave-results
+
+  - name: collect-wave-results
+    edit: false
+    persona: coder
+    policy:
+      - testing
+      - kiro-artifact-operations
+      - kiro-impl-task-progress
+    session: refresh
+    knowledge:
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Bash
+    required_permission_mode: readonly
+    pass_previous_response: false
+    instruction: kiro-impl-collect-wave-results
+    output_contracts:
+      report:
+        - name: kiro-task-wave-implementation-result.md
+          format: kiro-implementation-result
+    rules:
+      - condition: STATUS READY_FOR_REVIEW and dispatch_mode wave and wave_result_refs emitted
+        next: apply-wave-task
+      - condition: STATUS BLOCKED and selected task exists and blocker_note_required true
+        next: update-progress
+      - condition: STATUS BLOCKED
+        next: ABORT
+      - condition: STATUS NEEDS_CONTEXT
+        next: ABORT
+
+  - name: apply-wave-task
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+      - kiro-artifact-operations
+      - kiro-impl-task-progress
+    session: refresh
+    knowledge:
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+    required_permission_mode: edit
+    instruction: kiro-impl-apply-wave-task
+    output_contracts:
+      report:
+        - name: kiro-task-implementation-result.md
+          format: kiro-implementation-result
+    rules:
+      - condition: STATUS READY_FOR_REVIEW and selected task exists
+        next: ai-quality-gate
+      - condition: STATUS BLOCKED
+        next: debug-task
+      - condition: STATUS NEEDS_CONTEXT
+        next: debug-task
+
   - name: plan-one-task
     edit: false
     persona: planner
@@ -355,7 +542,7 @@ steps:
       - condition: STATUS READY_FOR_REVIEW and selected task checkbox updated and task_set_status ALL_TASKS_COMPLETE
         next: validate-impl-final
       - condition: STATUS READY_FOR_REVIEW and selected task checkbox updated and task_set_status REMAINING_TASKS_EXIST
-        next: plan-one-task
+        next: plan-dispatch
       - condition: STATUS BLOCKED and selected task blocker note written
         next: ABORT
       - condition: STATUS BLOCKED and progress update could not be written safely

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "takt-sdd",
-  "version": "1.1.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt-sdd",
-      "version": "1.1.0",
+      "version": "2.0.1",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "takt": "0.45.0"
+        "takt": "0.46.0"
       },
       "bin": {
         "takt-sdd": "bin/takt-sdd.mjs"
@@ -75,9 +75,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -90,9 +87,6 @@
       "integrity": "sha512-uu8MnPwFBc9ayFg5c94aHaqJVLS51oHNVxHwud4nK27GliP5WoME3F7pmm1N/Jyy2ry2E2CLNnsAm5l3zemfYA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -107,9 +101,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -122,9 +113,6 @@
       "integrity": "sha512-ofKxyp/N8+LLSrClt+dJo0laCHDzmBgmN8+Q+zabJ54Jqc1KXee68UsziE7kLCqGbOSY7rsIK9d22T1uQyZkUw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -443,9 +431,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.14.24",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.24.tgz",
-      "integrity": "sha512-hZWc1jx+gtZBM6Mff9iOMlXM1at9BbAGg0uNrQk8DuXpd8K19fu942emojdInO2zy0jC5/wWggsi7GJu7HMp/w==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.7.tgz",
+      "integrity": "sha512-7q7StGM+N0OwUgRsmDc8Gyz3hMIH1XGig+qZ4lzWUpmSgFEjLx8U7R14GXY7KiMJVdbVf6FeaYloRz2Rcsma4A==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -2955,17 +2943,20 @@
       "license": "MIT"
     },
     "node_modules/takt": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/takt/-/takt-0.45.0.tgz",
-      "integrity": "sha512-TjMhcQgwtVOzpZotyHwc0R4aVh2jfLCZvWqdck6Wzz4Ech8dWaJ/lAUaPdYivRDe3Cab+ik/lqYmJtyTxwwARw==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/takt/-/takt-0.46.0.tgz",
+      "integrity": "sha512-2sDIQgNqGWus8ynJEXx3Ha1UOfOzFaM0NR++FL+Hgv0dhsUu4Gy4mWwSqULQQ1nzkKSg8QpnhkN4qrz0WS5zYQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.170",
         "@openai/codex-sdk": "^0.137.0",
-        "@opencode-ai/sdk": "^1.14.24",
+        "@opencode-ai/sdk": "^1.17.3",
         "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
         "@opentelemetry/sdk-metrics": "^2.7.1",
         "@opentelemetry/sdk-node": "^0.218.0",
+        "@opentelemetry/sdk-trace-base": "^2.7.1",
         "ajv": "^6.12.6",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "LICENSE-APACHE"
   ],
   "dependencies": {
-    "takt": "0.45.0"
+    "takt": "0.46.0"
   },
   "scripts": {
     "build:installer": "npm --prefix installer ci && npm --prefix installer run build",

--- a/scripts/kiro-staged.mjs
+++ b/scripts/kiro-staged.mjs
@@ -8,8 +8,10 @@ import { fileURLToPath } from "node:url";
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 function configuredLanguage(root) {
-  const configPath = resolve(root, ".takt", "config.yaml");
-  if (!existsSync(configPath)) {
+  const configPath = [resolve(root, ".takt", "config.yaml"), resolve(root, ".takt", "config.yml")].find((path) =>
+    existsSync(path),
+  );
+  if (!configPath) {
     return undefined;
   }
   const match = readFileSync(configPath, "utf8").match(/^language:\s*(en|ja)\s*$/m);

--- a/scripts/validate-kiro-iterative-implementation-workflow.mjs
+++ b/scripts/validate-kiro-iterative-implementation-workflow.mjs
@@ -11,6 +11,151 @@ const languages = ["en", "ja"];
 
 const instructionSpecs = [
   {
+    name: "kiro-impl-plan-dispatch",
+    skill: "kiro-impl",
+    section: "## Step 2: Select Tasks & Determine Mode",
+    parent: "plan",
+    terms: [
+      "ready_for_implementation",
+      "spec.json",
+      "tasks.md",
+      "_Boundary:_",
+      "_Depends:_",
+      "(P)",
+      "dispatch_mode",
+      "wave",
+      "wave_apply",
+      "single",
+      "wave_tasks",
+      "first two",
+      "wave_result_refs",
+      "task_worktree",
+      "task_branch",
+      "baseline_dirty_files",
+      "selected_task",
+      "blocker_note_required",
+      "READY_FOR_REVIEW",
+      "BLOCKED",
+      "NEEDS_CONTEXT",
+    ],
+  },
+  {
+    name: "kiro-impl-prepare-task-wave",
+    skill: "kiro-impl",
+    section: "## Step 3: Execute Implementation",
+    parent: "fix",
+    terms: [
+      "dispatch_mode",
+      "wave_id",
+      "wave_tasks",
+      "wave_worktrees",
+      ".takt/worktrees/kiro-impl",
+      "kiro-impl/<feature>/<task-id>",
+      "task_worktree",
+      "task_branch",
+      "_Boundary:_",
+      "_Depends:_ none",
+      "manifest entry",
+      "baseline_dirty_files",
+      "selected_task",
+      "blocker_note_required",
+      "READY_FOR_REVIEW",
+      "BLOCKED",
+      "NEEDS_CONTEXT",
+    ],
+  },
+  {
+    name: "kiro-impl-execute-task-wave",
+    skill: "kiro-impl",
+    section: "## Step 3: Execute Implementation",
+    parent: "implement-after-tests",
+    terms: [
+      "TeamLeader",
+      "dispatch_mode",
+      "wave_id",
+      "wave_tasks",
+      "wave_result_refs",
+      "wave_part_status",
+      "task_worktree",
+      "task_branch",
+      "verbatim",
+      "validation command hint",
+      "Do not invent wave-id-derived branch names",
+      "literal boundary-file task",
+      "_Boundary:_",
+      "git -C <task_worktree>",
+      "main worktree",
+      "verification",
+      "filesystem evidence",
+      "part output",
+      "git -C <task_worktree> status --porcelain",
+      "done=true",
+      "parts: []",
+      "collect-wave-results",
+      "RED_PHASE_OUTPUT",
+      "changed_files",
+      "validation_evidence",
+      "READY_FOR_REVIEW",
+      "COMPLETE",
+      "BLOCKED",
+      "NEEDS_CONTEXT",
+    ],
+  },
+  {
+    name: "kiro-impl-collect-wave-results",
+    skill: "kiro-impl",
+    section: "## Step 3: Execute Implementation",
+    parent: "implement-after-tests",
+    terms: [
+      "dispatch_mode",
+      "wave_id",
+      "wave_tasks",
+      "wave_result_refs",
+      "wave_part_status",
+      "task_worktree",
+      "task_branch",
+      "_Boundary:_",
+      "manifest entry",
+      "filesystem evidence",
+      "part output",
+      "context/previous_responses/execute-task-wave",
+      "git -C <task_worktree> status --porcelain",
+      "git -C <task_worktree> ls-files --others --exclude-standard -- <boundary>",
+      "changed_files",
+      "validation_evidence",
+      "RED_PHASE_OUTPUT",
+      "READY_FOR_REVIEW",
+      "COMPLETE",
+      "BLOCKED",
+      "NEEDS_CONTEXT",
+      "apply-wave-task",
+    ],
+  },
+  {
+    name: "kiro-impl-apply-wave-task",
+    skill: "kiro-impl",
+    section: "## Step 3: Execute Implementation",
+    parent: "implement-after-tests",
+    terms: [
+      "dispatch_mode",
+      "wave_apply",
+      "wave_result_refs",
+      "wave_part_status",
+      "selected_task",
+      "task_worktree",
+      "task_branch",
+      "baseline_dirty_files",
+      "changed_files",
+      "validation_evidence",
+      "RED_PHASE_OUTPUT",
+      "kiro-task-implementation-result.md",
+      "READY_FOR_REVIEW",
+      "COMPLETE",
+      "BLOCKED",
+      "NEEDS_CONTEXT",
+    ],
+  },
+  {
     name: "kiro-impl-plan-one-task",
     skill: "kiro-impl",
     section: "## Step 2: Select Tasks & Determine Mode",
@@ -255,11 +400,22 @@ const outputContractSpecs = [
       "task_set_status",
       "executable leaf task",
       "group header",
+      "dispatch_mode",
+      "wave_id",
+      "wave_tasks",
+      "wave_worktrees",
+      "wave_result_refs",
+      "wave_part_status",
+      "task_worktree",
+      "task_branch",
       "baseline_dirty_files",
       "changed_files",
       "validation_evidence",
       "missing_context",
       "RED_PHASE_OUTPUT",
+      "Report Preservation",
+      "APPROVE",
+      "REJECT",
       "summary",
     ],
   },
@@ -319,6 +475,11 @@ const workflowPolicyNames = [
   "kiro-impl-task-progress",
 ];
 const expectedSteps = [
+  "plan-dispatch",
+  "prepare-task-wave",
+  "execute-task-wave",
+  "collect-wave-results",
+  "apply-wave-task",
   "plan-one-task",
   "execute-task",
   "ai-quality-gate",
@@ -535,7 +696,7 @@ function validateWorkflowFiles(repoRoot) {
       content,
       [
         "name: kiro-impl",
-        "initial_step: plan-one-task",
+        "initial_step: plan-dispatch",
         "max_steps: 200",
         "loop_monitors:",
         "threshold:",
@@ -567,6 +728,95 @@ function validateWorkflowFiles(repoRoot) {
       if (!facetReferenceExists(repoRoot, lang, "personas", persona)) {
         failures.push(`RESOURCE_REFERENCE_DRIFT: ${rel(repoRoot, workflowPath)} persona references missing resource ${persona}`);
       }
+    }
+    const dispatchBlock = blocks.get("plan-dispatch") ?? [];
+    if (stepScalar(dispatchBlock, "session") !== "refresh") {
+      failures.push(`SESSION_DRIFT: ${rel(repoRoot, workflowPath)} plan-dispatch must refresh session on each dispatch pass`);
+    }
+    if (stepScalar(dispatchBlock, "pass_previous_response") !== "false") {
+      failures.push(`SESSION_DRIFT: ${rel(repoRoot, workflowPath)} plan-dispatch must not inherit progress or wave-apply responses when selecting the next route`);
+    }
+    if (!hasRuleWithTerms(dispatchBlock, ["dispatch_mode wave", "wave_tasks emitted", "next: prepare-task-wave"])) {
+      failures.push(`TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} plan-dispatch must route safe (P) waves to prepare-task-wave`);
+    }
+    if (!hasRuleWithTerms(dispatchBlock, ["dispatch_mode wave_apply", "wave_result_refs emitted", "next: apply-wave-task"])) {
+      failures.push(`TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} plan-dispatch must route unapplied wave results to apply-wave-task`);
+    }
+    if (!hasRuleWithTerms(dispatchBlock, ["dispatch_mode single", "next: plan-one-task"])) {
+      failures.push(`TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} plan-dispatch must fall back to plan-one-task when no safe (P) wave exists`);
+    }
+    if (!hasRuleWithTerms(dispatchBlock, ["selected task exists", "blocker_note_required true", "next: update-progress"])) {
+      failures.push(`TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} plan-dispatch must route selected-task blockers to update-progress`);
+    }
+    const prepareWaveBlock = blocks.get("prepare-task-wave") ?? [];
+    if (stepScalar(prepareWaveBlock, "edit") !== "true" || stepScalar(prepareWaveBlock, "required_permission_mode") !== "full") {
+      failures.push(
+        `TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} prepare-task-wave must run with full permission because git worktree setup writes .git refs`,
+      );
+    }
+    if (!hasRuleWithTerms(prepareWaveBlock, ["dispatch_mode wave", "wave_tasks emitted", "wave_worktrees prepared", "next: execute-task-wave"])) {
+      failures.push(`TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} prepare-task-wave must route prepared waves to execute-task-wave`);
+    }
+    if (!hasRuleWithTerms(prepareWaveBlock, ["selected task exists", "blocker_note_required true", "next: update-progress"])) {
+      failures.push(`TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} prepare-task-wave must route selected-task blockers to update-progress`);
+    }
+    const executeWaveBlock = blocks.get("execute-task-wave") ?? [];
+    containsAll(
+      executeWaveBlock.join("\n"),
+      [
+        "team_leader:",
+        "max_parts: 2",
+        "refill_threshold: 0",
+        "part_persona: coder",
+        "part_edit: true",
+        "part_permission_mode: edit",
+        "part_allowed_tools:",
+      ],
+      workflowPath,
+      failures,
+      repoRoot,
+      "TEAMLEADER_WAVE_DRIFT",
+    );
+    if (executeWaveBlock.join("\n").includes("name: kiro-task-wave-implementation-result.md")) {
+      failures.push(`TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} execute-task-wave must not run report phase; collect-wave-results owns wave result reporting`);
+    }
+    if (!hasRuleWithTerms(executeWaveBlock, ['condition: "true"', "next: collect-wave-results"])) {
+      failures.push(`TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} execute-task-wave must always route completed TeamLeader execution to collect-wave-results`);
+    }
+    const collectWaveBlock = blocks.get("collect-wave-results") ?? [];
+    containsAll(
+      collectWaveBlock.join("\n"),
+      [
+        "instruction: kiro-impl-collect-wave-results",
+        "pass_previous_response: false",
+        "name: kiro-task-wave-implementation-result.md",
+        "format: kiro-implementation-result",
+      ],
+      workflowPath,
+      failures,
+      repoRoot,
+      "TEAMLEADER_WAVE_DRIFT",
+    );
+    if (!hasRuleWithTerms(collectWaveBlock, ["dispatch_mode wave", "wave_result_refs emitted", "next: apply-wave-task"])) {
+      failures.push(`TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} collect-wave-results must route ready wave results to apply-wave-task`);
+    }
+    if (!hasRuleWithTerms(collectWaveBlock, ["selected task exists", "blocker_note_required true", "next: update-progress"])) {
+      failures.push(`TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} collect-wave-results must route selected-task blockers to update-progress`);
+    }
+    const applyWaveBlock = blocks.get("apply-wave-task") ?? [];
+    containsAll(
+      applyWaveBlock.join("\n"),
+      ["instruction: kiro-impl-apply-wave-task", "name: kiro-task-implementation-result.md", "format: kiro-implementation-result"],
+      workflowPath,
+      failures,
+      repoRoot,
+      "TEAMLEADER_WAVE_DRIFT",
+    );
+    if (!hasRuleWithTerms(applyWaveBlock, ["STATUS READY_FOR_REVIEW", "selected task exists", "next: ai-quality-gate"])) {
+      failures.push(`TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} apply-wave-task must rejoin the normal ai-quality-gate path`);
+    }
+    if (!hasRuleWithTerms(applyWaveBlock, ["STATUS BLOCKED", "next: debug-task"])) {
+      failures.push(`TEAMLEADER_WAVE_DRIFT: ${rel(repoRoot, workflowPath)} apply-wave-task must route BLOCKED to debug-task for single-task fallback repair`);
     }
     const planBlock = blocks.get("plan-one-task") ?? [];
     if (stepScalar(planBlock, "session") !== "refresh") {
@@ -709,8 +959,8 @@ function validateWorkflowFiles(repoRoot) {
     if (!hasRuleWithTerms(updateBlock, ["STATUS READY_FOR_REVIEW", "selected task checkbox updated", "task_set_status ALL_TASKS_COMPLETE", "next: validate-impl-final"])) {
       failures.push(`FIELD_CONTRACT_DRIFT: ${rel(repoRoot, workflowPath)} update-progress must route successful final checkbox updates to validate-impl-final`);
     }
-    if (!hasRuleWithTerms(updateBlock, ["STATUS READY_FOR_REVIEW", "selected task checkbox updated", "task_set_status REMAINING_TASKS_EXIST", "next: plan-one-task"])) {
-      failures.push(`FIELD_CONTRACT_DRIFT: ${rel(repoRoot, workflowPath)} update-progress must route non-final checkbox updates back to plan-one-task`);
+    if (!hasRuleWithTerms(updateBlock, ["STATUS READY_FOR_REVIEW", "selected task checkbox updated", "task_set_status REMAINING_TASKS_EXIST", "next: plan-dispatch"])) {
+      failures.push(`FIELD_CONTRACT_DRIFT: ${rel(repoRoot, workflowPath)} update-progress must route non-final checkbox updates back to plan-dispatch`);
     }
     if (hasRuleWithTerms(updateBlock, ["task_set_status REMAINING_TASKS_EXIST", "next: COMPLETE"])) {
       failures.push(`FIELD_CONTRACT_DRIFT: ${rel(repoRoot, workflowPath)} update-progress must not complete while remaining tasks exist`);
@@ -1064,6 +1314,14 @@ function validateLanguageParity(repoRoot) {
         "need_replan",
         "kiro-ai-antipattern-review.md",
         "kiro-ai-antipattern-fix.md",
+        "dispatch_mode",
+        "wave_id",
+        "wave_tasks",
+        "wave_worktrees",
+        "wave_result_refs",
+        "wave_part_status",
+        "task_worktree",
+        "task_branch",
       ])
       .filter((term) => readText(enPath).includes(term));
     for (const term of enMachineTerms) {
@@ -1126,6 +1384,9 @@ function validateTaskFixtureCoverage(repoRoot) {
     [
       "validator rejects completion-before-checkbox gate drift",
       "validator rejects readiness routing that skips ready-for-implementation",
+      "validator rejects dispatch routing that bypasses single-task fallback",
+      "validator rejects TeamLeader wave execution without team_leader configuration",
+      "validator rejects wave apply routing that bypasses AI quality gate",
       "validator rejects blocked execution routing to reviewers",
       "validator rejects direct review routing that bypasses AI quality gate",
       "validator rejects missing parallel reviewer group",
@@ -1150,6 +1411,8 @@ function validateTaskFixtureCoverage(repoRoot) {
       "validator rejects progress adapter reading AI gate reports directly",
       "validator rejects plan blockers that bypass progress blocker notes",
       "validator rejects progress updates that omit routing status outputs",
+      "validator rejects progress routing that skips dispatch re-entry",
+      "validator rejects implementation result contract without wave dispatch fields",
       "validator rejects progress policy drift that loses selected task guard",
     ],
     testPath,

--- a/tests/kiro-ai-quality-gate-runtime-smoke.test.mjs
+++ b/tests/kiro-ai-quality-gate-runtime-smoke.test.mjs
@@ -263,6 +263,13 @@ No production files are owned by this fixture.
 
 function writeMockScenario(root) {
   const entries = [
+    { persona: "planner", content: "Dispatch smoke task through the single-task fallback. STATUS: READY_FOR_REVIEW." },
+    {
+      persona: "planner",
+      content:
+        "## Status Report\n\nSTATUS: READY_FOR_REVIEW\nready_for_implementation: true\ndispatch_mode: single\nwave_tasks: N/A\nwave_result_refs: N/A\nbaseline_dirty_files: none\nsummary: no safe (P) wave, use single task path",
+    },
+    { persona: "conductor", content: '{"step":3}', structured_output: { step: 3 } },
     { persona: "planner", content: "Plan smoke task. STATUS: READY_FOR_REVIEW." },
     {
       persona: "planner",
@@ -782,9 +789,9 @@ test("kiro full lifecycle smoke runs init, requirements, design, tasks, and impl
       writeMockScenario(root),
     );
     assert.equal(implementation.status, 0, implementation.output);
-    assert.match(implementation.output, /\[3\/200\] ai-quality-gate/);
-    assert.match(implementation.output, /\[5\/200\] reviewers/);
-    assert.match(implementation.output, /\[8\/200\] validate-impl-final/);
+    assert.match(implementation.output, /\[4\/200\] ai-quality-gate/);
+    assert.match(implementation.output, /\[6\/200\] reviewers/);
+    assert.match(implementation.output, /\[9\/200\] validate-impl-final/);
     assert.match(implementation.output, /Result: Success/);
 
     const reportRoot = join(root, ".takt", "runs");
@@ -813,11 +820,11 @@ test("kiro impl runtime wiring calls AI quality gate subworkflow and returns to 
     const output = workflowOutput(result);
 
     assert.equal(result.status, 0, output);
-    assert.match(output, /\[3\/200\] ai-quality-gate/);
-    assert.match(output, /\[4\/200\] ai-antipattern-review-1st/);
+    assert.match(output, /\[4\/200\] ai-quality-gate/);
+    assert.match(output, /\[5\/200\] ai-antipattern-review-1st/);
     assert.match(output, /Status: COMPLETE/);
-    assert.match(output, /\[5\/200\] reviewers/);
-    assert.match(output, /\[8\/200\] validate-impl-final/);
+    assert.match(output, /\[6\/200\] reviewers/);
+    assert.match(output, /\[9\/200\] validate-impl-final/);
     assert.match(output, /Result: Success/);
 
     const reportRoot = join(root, ".takt", "runs");

--- a/tests/kiro-iterative-implementation-workflow.test.mjs
+++ b/tests/kiro-iterative-implementation-workflow.test.mjs
@@ -88,6 +88,14 @@ test("staged Kiro wrapper resolves configured language workflow path", () => {
   ]);
 });
 
+test("staged Kiro wrapper resolves configured language from config.yml fallback", () => {
+  const root = makeCurrentSurfaceFixture();
+  rmSync(join(root, ".takt", "config.yaml"), { force: true });
+  writeFixtureFile(root, ".takt/config.yml", "language: en\n");
+
+  assert.equal(resolveWorkflowPath(root, "kiro-impl"), join(root, ".takt", "en", "workflows", "kiro-impl.yaml"));
+});
+
 test("validator accepts body Kiro Skill Source instructions", () => {
   const root = makeCurrentSurfaceFixture();
 
@@ -185,6 +193,94 @@ test("validator rejects readiness routing that skips ready-for-implementation", 
 
   assert.equal(result.ok, false);
   assert.ok(result.failures.some((failure) => failure.includes("readiness before edit")));
+});
+
+test("validator rejects dispatch routing that bypasses single-task fallback", () => {
+  const root = makeCurrentSurfaceFixture();
+  const workflowPath = join(root, ".takt", "en", "workflows", "kiro-impl.yaml");
+  const workflow = readFileSync(workflowPath, "utf8").replace(
+    "STATUS READY_FOR_REVIEW and dispatch_mode single\n        next: plan-one-task",
+    "STATUS READY_FOR_REVIEW and dispatch_mode single\n        next: execute-task",
+  );
+  writeFixtureFile(root, ".takt/en/workflows/kiro-impl.yaml", workflow);
+
+  const result = validateKiroIterativeImplementationWorkflow({ repoRoot: root });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.failures.some((failure) => failure.includes("fall back to plan-one-task")));
+});
+
+test("validator rejects TeamLeader wave execution without team_leader configuration", () => {
+  const root = makeCurrentSurfaceFixture();
+  const workflowPath = join(root, ".takt", "ja", "workflows", "kiro-impl.yaml");
+  const workflow = readFileSync(workflowPath, "utf8").replace("    team_leader:\n", "    leader:\n");
+  writeFixtureFile(root, ".takt/ja/workflows/kiro-impl.yaml", workflow);
+
+  const result = validateKiroIterativeImplementationWorkflow({ repoRoot: root });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.failures.some((failure) => failure.includes("team_leader:")));
+});
+
+test("validator rejects wave collection reverting to planning parent", () => {
+  const root = makeCurrentSurfaceFixture();
+  const collectPath = join(root, ".takt", "en", "facets", "instructions", "kiro-impl-collect-wave-results.md");
+  const collect = readFileSync(collectPath, "utf8").replace("{extends: implement-after-tests}", "{extends: plan}");
+  writeFixtureFile(root, ".takt/en/facets/instructions/kiro-impl-collect-wave-results.md", collect);
+
+  const result = validateKiroIterativeImplementationWorkflow({ repoRoot: root });
+
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some(
+      (failure) => failure.includes("kiro-impl-collect-wave-results.md") && failure.includes("implement-after-tests"),
+    ),
+  );
+});
+
+test("validator rejects wave collection that omits COMPLETE part status handling", () => {
+  const root = makeCurrentSurfaceFixture();
+  const collectPath = join(root, ".takt", "ja", "facets", "instructions", "kiro-impl-collect-wave-results.md");
+  const collect = readFileSync(collectPath, "utf8").replaceAll("COMPLETE", "DONE");
+  writeFixtureFile(root, ".takt/ja/facets/instructions/kiro-impl-collect-wave-results.md", collect);
+
+  const result = validateKiroIterativeImplementationWorkflow({ repoRoot: root });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.failures.some((failure) => failure.includes("kiro-impl-collect-wave-results.md") && failure.includes("COMPLETE")));
+});
+
+test("validator rejects wave execution that can invent task branch names", () => {
+  const root = makeCurrentSurfaceFixture();
+  const executePath = join(root, ".takt", "en", "facets", "instructions", "kiro-impl-execute-task-wave.md");
+  const execute = readFileSync(executePath, "utf8").replace("Do not invent wave-id-derived branch names", "Use clear branch names");
+  writeFixtureFile(root, ".takt/en/facets/instructions/kiro-impl-execute-task-wave.md", execute);
+
+  const result = validateKiroIterativeImplementationWorkflow({ repoRoot: root });
+
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some(
+      (failure) =>
+        failure.includes("kiro-impl-execute-task-wave.md") &&
+        failure.includes("Do not invent wave-id-derived branch names"),
+    ),
+  );
+});
+
+test("validator rejects wave apply routing that bypasses AI quality gate", () => {
+  const root = makeCurrentSurfaceFixture();
+  const workflowPath = join(root, ".takt", "en", "workflows", "kiro-impl.yaml");
+  const workflow = readFileSync(workflowPath, "utf8").replace(
+    "STATUS READY_FOR_REVIEW and selected task exists\n        next: ai-quality-gate",
+    "STATUS READY_FOR_REVIEW and selected task exists\n        next: reviewers",
+  );
+  writeFixtureFile(root, ".takt/en/workflows/kiro-impl.yaml", workflow);
+
+  const result = validateKiroIterativeImplementationWorkflow({ repoRoot: root });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.failures.some((failure) => failure.includes("apply-wave-task must rejoin")));
 });
 
 test("validator rejects blocked execution routing to reviewers", () => {
@@ -626,6 +722,33 @@ test("validator rejects progress routing that drops task set status", () => {
   assert.ok(result.failures.some((failure) => failure.includes("update-progress")));
 });
 
+test("validator rejects progress routing that skips dispatch re-entry", () => {
+  const root = makeCurrentSurfaceFixture();
+  const workflowPath = join(root, ".takt", "ja", "workflows", "kiro-impl.yaml");
+  const workflow = readFileSync(workflowPath, "utf8").replace(
+    "task_set_status REMAINING_TASKS_EXIST\n        next: plan-dispatch",
+    "task_set_status REMAINING_TASKS_EXIST\n        next: plan-one-task",
+  );
+  writeFixtureFile(root, ".takt/ja/workflows/kiro-impl.yaml", workflow);
+
+  const result = validateKiroIterativeImplementationWorkflow({ repoRoot: root });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.failures.some((failure) => failure.includes("back to plan-dispatch")));
+});
+
+test("validator rejects implementation result contract without wave dispatch fields", () => {
+  const root = makeCurrentSurfaceFixture();
+  const contractPath = join(root, ".takt", "en", "facets", "output-contracts", "kiro-implementation-result.md");
+  const contract = readFileSync(contractPath, "utf8").replaceAll("dispatch_mode", "execution_mode");
+  writeFixtureFile(root, ".takt/en/facets/output-contracts/kiro-implementation-result.md", contract);
+
+  const result = validateKiroIterativeImplementationWorkflow({ repoRoot: root });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.failures.some((failure) => failure.includes("dispatch_mode")));
+});
+
 test("validator rejects progress updates that count group header checkboxes as remaining tasks", () => {
   const root = makeCurrentSurfaceFixture();
   const progressPath = join(root, ".takt", "en", "facets", "instructions", "kiro-impl-update-progress.md");
@@ -651,7 +774,7 @@ test("validator rejects single-shot completion when tasks remain", () => {
   const root = makeCurrentSurfaceFixture();
   const workflowPath = join(root, ".takt", "ja", "workflows", "kiro-impl.yaml");
   const workflow = readFileSync(workflowPath, "utf8").replace(
-    "task_set_status REMAINING_TASKS_EXIST\n        next: plan-one-task",
+    "task_set_status REMAINING_TASKS_EXIST\n        next: plan-dispatch",
     "task_set_status REMAINING_TASKS_EXIST\n        next: COMPLETE",
   );
   writeFixtureFile(root, ".takt/ja/workflows/kiro-impl.yaml", workflow);

--- a/tests/kiro-real-provider-smoke.test.mjs
+++ b/tests/kiro-real-provider-smoke.test.mjs
@@ -2,14 +2,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { spawn, spawnSync } from "node:child_process";
 
 // Real-provider smoke intentionally uses semantic assertions instead of exact
-// generated text because Claude output can vary. Mock-provider smoke tests
+// generated text because provider output can vary. Mock-provider smoke tests
 // should stay strict and deterministic.
 const featureName = "kiro-real-provider-smoke";
-const defaultModel = "claude-opus-4-8";
 const defaultWorkflowTimeoutMs = 900000;
 const defaultImplWorkflowTimeoutMs = 1800000;
 const fatalWorkflowPatterns = [
@@ -27,6 +26,61 @@ function writeFixtureFile(root, path, content) {
   const fullPath = join(root, path);
   mkdirSync(dirname(fullPath), { recursive: true });
   writeFileSync(fullPath, content);
+}
+
+function runFixtureCommand(root, command, args) {
+  const result = spawnSync(command, args, { cwd: root, encoding: "utf8" });
+  assert.equal(result.status, 0, `${command} ${args.join(" ")} failed\n${result.stdout}\n${result.stderr}`);
+  return result;
+}
+
+function initializeFixtureGit(root) {
+  runFixtureCommand(root, "git", ["init", "-b", "main"]);
+  runFixtureCommand(root, "git", ["config", "user.email", "kiro-smoke@example.test"]);
+  runFixtureCommand(root, "git", ["config", "user.name", "Kiro Smoke"]);
+  commitFixtureState(root, "initial smoke fixture");
+}
+
+function commitFixtureState(root, message) {
+  const status = spawnSync("git", ["status", "--porcelain"], { cwd: root, encoding: "utf8" });
+  assert.equal(status.status, 0, `git status failed\n${status.stdout}\n${status.stderr}`);
+  if (!status.stdout.trim()) {
+    return;
+  }
+  runFixtureCommand(root, "git", ["add", "."]);
+  runFixtureCommand(root, "git", ["commit", "-m", message]);
+}
+
+function fixtureConfigPath(root) {
+  for (const name of ["config.yaml", "config.yml"]) {
+    const path = join(root, ".takt", name);
+    if (existsSync(path)) {
+      return path;
+    }
+  }
+  assert.fail("expected .takt/config.yaml or .takt/config.yml in real-provider smoke fixture");
+}
+
+function configuredProvider(root) {
+  const config = readFileSync(fixtureConfigPath(root), "utf8");
+  return config.match(/^provider:\s*(\S+)\s*$/m)?.[1];
+}
+
+function linkCodexHomeIfConfigured(root) {
+  if (configuredProvider(root) !== "codex") {
+    return;
+  }
+  const candidates = [
+    process.env.KIRO_REAL_PROVIDER_CODEX_HOME,
+    process.env.CODEX_HOME,
+    join(homedir(), ".codex-personal"),
+  ].filter(Boolean);
+  const codexHome = candidates.find((path) => existsSync(path));
+  assert.ok(
+    codexHome,
+    "provider is codex; set CODEX_HOME or KIRO_REAL_PROVIDER_CODEX_HOME, or create ~/.codex-personal",
+  );
+  symlinkSync(codexHome, join(root, ".codex"), "dir");
 }
 
 function makeRealProviderFixture() {
@@ -59,17 +113,8 @@ function makeRealProviderFixture() {
       2,
     )}\n`,
   );
-  writeFixtureFile(
-    root,
-    ".takt/config.yaml",
-    `provider: claude
-language: ja
-model: ${process.env.KIRO_REAL_PROVIDER_MODEL ?? defaultModel}
-concurrency: 1
-base_branch: main
-submodules: all
-`,
-  );
+  writeFixtureFile(root, ".gitignore", ".codex\n.takt/runs/\n.takt/worktrees/\n");
+  linkCodexHomeIfConfigured(root);
   writeFixtureFile(root, ".kiro/steering/product.md", "# Product\n\nReal-provider smoke fixture for TAKT/Kiro workflow validation.\n");
   writeFixtureFile(root, ".kiro/steering/tech.md", "# Tech\n\nUse only local files in this temporary fixture.\n");
   writeFixtureFile(root, ".kiro/steering/structure.md", "# Structure\n\nSmoke artifacts may be written under `smoke-output/` only.\n");
@@ -79,17 +124,129 @@ submodules: all
     `.kiro/specs/${featureName}/brief.md`,
     `# Brief
 
-Create a minimal Kiro full-chain smoke spec using the real Claude provider.
+Create a minimal Kiro full-chain smoke spec using the configured real provider.
 
 The implementation must be tiny and deterministic:
 
-- Own only \`smoke-output/provider-smoke.txt\`.
-- The final implementation task should create or update that file with a short line containing \`claude provider smoke passed\`.
+- Own only \`smoke-output/provider-smoke-alpha.txt\` and \`smoke-output/provider-smoke-beta.txt\`.
+- The final implementation tasks should be independent and parallelizable.
+- One task should create or update \`smoke-output/provider-smoke-alpha.txt\` with a short line containing \`real provider smoke passed alpha\`.
+- One task should create or update \`smoke-output/provider-smoke-beta.txt\` with a short line containing \`real provider smoke passed beta\`.
 - Do not change production files, package metadata, workflows, facets, scripts, or settings.
 - Keep requirements, design, and tasks minimal but valid.
 `,
   );
+  initializeFixtureGit(root);
   return root;
+}
+
+function writeParallelProviderSmokeImplementationArtifacts(root) {
+  const now = new Date().toISOString();
+  writeFixtureFile(
+    root,
+    `.kiro/specs/${featureName}/requirements.md`,
+    `# Requirements Document
+
+## Requirements
+
+### Requirement 1: Parallel real-provider smoke outputs
+
+**User Story:** As a workflow maintainer, I want two tiny independent implementation tasks, so that the real-provider smoke covers the TeamLeader \`(P)\` route.
+
+#### Acceptance Criteria
+
+1. WHEN implementation completes THEN \`smoke-output/provider-smoke-alpha.txt\` SHALL contain \`real provider smoke passed alpha\`.
+2. WHEN implementation completes THEN \`smoke-output/provider-smoke-beta.txt\` SHALL contain \`real provider smoke passed beta\`.
+`,
+  );
+  writeFixtureFile(
+    root,
+    `.kiro/specs/${featureName}/design.md`,
+    `# Design Document
+
+## Overview
+
+This fixture validates the real-provider Kiro implementation workflow with two independent \`(P)\` tasks.
+
+## Boundary Commitments
+
+### This Spec Owns
+
+- \`smoke-output/provider-smoke-alpha.txt\`
+- \`smoke-output/provider-smoke-beta.txt\`
+
+### Out of Boundary
+
+- Production files, package metadata, workflows, facets, scripts, and settings.
+
+### Allowed Dependencies
+
+- Existing Kiro implementation workflow and local filesystem writes.
+
+### Revalidation Triggers
+
+- Kiro implementation workflow routing changes.
+
+## File Structure Plan
+
+\`\`\`
+smoke-output/
+  provider-smoke-alpha.txt
+  provider-smoke-beta.txt
+\`\`\`
+
+## Requirements Traceability
+
+| Requirement | Design Element |
+|-------------|----------------|
+| 1.1 | \`provider-smoke-alpha.txt\` |
+| 1.2 | \`provider-smoke-beta.txt\` |
+`,
+  );
+  writeFixtureFile(
+    root,
+    `.kiro/specs/${featureName}/tasks.md`,
+    `# Implementation Plan
+
+- [ ] 1. Create parallel real-provider smoke outputs
+- [ ] 1.1 (P) Write alpha smoke output
+  - Create or update \`smoke-output/provider-smoke-alpha.txt\`.
+  - The file must contain \`real provider smoke passed alpha\`.
+  - _Requirements: 1.1_
+  - _Boundary:_ smoke-output/provider-smoke-alpha.txt
+  - _Depends:_ none
+- [ ] 1.2 (P) Write beta smoke output
+  - Create or update \`smoke-output/provider-smoke-beta.txt\`.
+  - The file must contain \`real provider smoke passed beta\`.
+  - _Requirements: 1.2_
+  - _Boundary:_ smoke-output/provider-smoke-beta.txt
+  - _Depends:_ none
+`,
+  );
+  const spec = existsSync(join(root, ".kiro", "specs", featureName, "spec.json"))
+    ? readSpec(root)
+    : {
+        feature_name: featureName,
+        created_at: now,
+        updated_at: now,
+        language: "ja",
+        phase: "initialized",
+        approvals: {
+          requirements: { generated: false, approved: false },
+          design: { generated: false, approved: false },
+          tasks: { generated: false, approved: false },
+        },
+        ready_for_implementation: false,
+      };
+  spec.phase = "tasks-generated";
+  spec.approvals = {
+    requirements: { generated: true, approved: true },
+    design: { generated: true, approved: true },
+    tasks: { generated: true, approved: true },
+  };
+  spec.ready_for_implementation = true;
+  spec.updated_at = now;
+  writeFixtureFile(root, `.kiro/specs/${featureName}/spec.json`, `${JSON.stringify(spec, null, 2)}\n`);
 }
 
 function terminateProcessGroup(child, signal) {
@@ -149,6 +306,7 @@ function runWorkflow(root, scriptName, target, options = {}) {
   delete env.NO_COLOR;
   const timeoutMs = options.timeoutMs ?? workflowTimeoutMs(scriptName);
   const patterns = options.fatalPatterns ?? fatalWorkflowPatterns;
+  const successWhen = options.successWhen;
   const targetArgs = Array.isArray(target) ? target : [target];
 
   return new Promise((resolve) => {
@@ -160,13 +318,18 @@ function runWorkflow(root, scriptName, target, options = {}) {
     });
     let output = "";
     let earlyAbortReason = "";
+    let earlySuccessReason = "";
     let killTimer;
 
-    const abort = (reason) => {
-      if (earlyAbortReason) {
+    const abort = (reason, { success = false } = {}) => {
+      if (earlyAbortReason || earlySuccessReason) {
         return;
       }
-      earlyAbortReason = reason;
+      if (success) {
+        earlySuccessReason = reason;
+      } else {
+        earlyAbortReason = reason;
+      }
       terminateProcessGroup(child, "SIGTERM");
       terminateFixtureProcesses(root, "SIGTERM");
       killTimer = setTimeout(() => {
@@ -185,6 +348,15 @@ function runWorkflow(root, scriptName, target, options = {}) {
       if (matchedPattern) {
         abort(`fatal workflow output matched ${matchedPattern}`);
       }
+      let successConditionMet = false;
+      try {
+        successConditionMet = Boolean(successWhen?.({ output: stripAnsi(output), root }));
+      } catch {
+        successConditionMet = false;
+      }
+      if (successConditionMet) {
+        abort("success condition satisfied", { success: true });
+      }
     };
 
     child.stdout.on("data", onOutput);
@@ -199,13 +371,14 @@ function runWorkflow(root, scriptName, target, options = {}) {
     child.on("close", (status, signal) => {
       clearTimeout(timeout);
       clearTimeout(killTimer);
-      if (earlyAbortReason) {
+      if (earlyAbortReason || earlySuccessReason) {
         terminateFixtureProcesses(root, "SIGKILL");
       }
       resolve({
         status,
         signal,
         earlyAbortReason,
+        earlySuccessReason,
         output,
       });
     });
@@ -224,6 +397,16 @@ function assertRealProviderWorkflowSuccess(result, name) {
   assertWorkflowSuccess(result, name);
 }
 
+function assertRealProviderEarlySmokeSuccess(result, name) {
+  const output = stripAnsi(result.output);
+  assert.equal(result.earlyAbortReason, "", `${name} stopped early: ${result.earlyAbortReason}\n${output}`);
+  if (result.earlySuccessReason) {
+    assert.equal(result.earlySuccessReason, "success condition satisfied", `${name} stopped unexpectedly\n${output}`);
+    return;
+  }
+  assertWorkflowSuccess(result, name);
+}
+
 function assertRealProviderPhase(root, phase, requiredArtifacts = []) {
   assert.equal(readSpec(root).phase, phase);
   for (const artifact of requiredArtifacts) {
@@ -231,17 +414,62 @@ function assertRealProviderPhase(root, phase, requiredArtifacts = []) {
   }
 }
 
-function hasGoDecision(report) {
-  return /(?:^|\n)\s*(?:-\s*)?`?DECISION`?\s*(?::|=)\s*`?GO`?\b/im.test(report);
+function latestReportsDirIfAny(root) {
+  const runRoot = join(root, ".takt", "runs");
+  if (!existsSync(runRoot)) {
+    return undefined;
+  }
+  const latestRun = readdirSync(runRoot)
+    .filter((entry) => statSync(join(runRoot, entry)).isDirectory())
+    .sort()
+    .at(-1);
+  return latestRun ? join(runRoot, latestRun, "reports") : undefined;
 }
 
-function assertRealProviderSmokeOutcome(root) {
-  const reportsDir = latestReportsDir(root);
-  const finalReport = readFileSync(join(reportsDir, "kiro-final-implementation-validation.md"), "utf8");
-  assert.equal(hasGoDecision(finalReport), true, `expected final validation to report GO\n${finalReport}`);
+function hasCollectedWaveResults(root) {
+  const reportsDir = latestReportsDirIfAny(root);
+  if (!reportsDir) {
+    return false;
+  }
+  const waveReportPath = join(reportsDir, "kiro-task-wave-implementation-result.md");
+  if (!existsSync(waveReportPath)) {
+    return false;
+  }
+  const waveReport = readFileSync(waveReportPath, "utf8");
+  return (
+    /STATUS:\s*READY_FOR_REVIEW/.test(waveReport) &&
+    /dispatch_mode:\s*wave/.test(waveReport) &&
+    /wave[_\s]+result[_\s]+refs/i.test(waveReport) &&
+    /Task 1\.1/.test(waveReport) &&
+    /Task 1\.2/.test(waveReport) &&
+    existsSync(join(root, ".takt", "worktrees", "kiro-impl", featureName, "1.1", "smoke-output", "provider-smoke-alpha.txt")) &&
+    existsSync(join(root, ".takt", "worktrees", "kiro-impl", featureName, "1.2", "smoke-output", "provider-smoke-beta.txt"))
+  );
+}
 
-  const smokeOutput = readFileSync(join(root, "smoke-output", "provider-smoke.txt"), "utf8");
-  assert.match(smokeOutput, /claude provider smoke passed/i);
+function assertRealProviderWaveSmokeOutcome(root) {
+  const reportsDir = latestReportsDir(root);
+  const waveReport = readFileSync(join(reportsDir, "kiro-task-wave-implementation-result.md"), "utf8");
+  assert.match(waveReport, /STATUS:\s*READY_FOR_REVIEW/);
+  assert.match(waveReport, /dispatch_mode:\s*wave/);
+  assert.match(waveReport, /wave[_\s]+result[_\s]+refs/i);
+  assert.match(waveReport, /Task 1\.1/);
+  assert.match(waveReport, /Task 1\.2/);
+
+  const alphaOutput = readFileSync(
+    join(root, ".takt", "worktrees", "kiro-impl", featureName, "1.1", "smoke-output", "provider-smoke-alpha.txt"),
+    "utf8",
+  );
+  const betaOutput = readFileSync(
+    join(root, ".takt", "worktrees", "kiro-impl", featureName, "1.2", "smoke-output", "provider-smoke-beta.txt"),
+    "utf8",
+  );
+  assert.match(alphaOutput, /real provider smoke passed alpha/i);
+  assert.match(betaOutput, /real provider smoke passed beta/i);
+
+  const tasks = readFileSync(join(root, ".kiro", "specs", featureName, "tasks.md"), "utf8");
+  assert.match(tasks, /1\.1 \(P\)/);
+  assert.match(tasks, /1\.2 \(P\)/);
 }
 
 function readSpec(root) {
@@ -332,28 +560,29 @@ setInterval(() => {}, 60000);
 });
 
 test(
-  "kiro full lifecycle smoke runs with the real Claude provider",
-  { skip: process.env.KIRO_REAL_PROVIDER_SMOKE === "1" ? false : "set KIRO_REAL_PROVIDER_SMOKE=1 to call the real Claude provider" },
+  "kiro impl smoke runs with the configured real provider and (P) implementation tasks",
+  { skip: process.env.KIRO_REAL_PROVIDER_SMOKE === "1" ? false : "set KIRO_REAL_PROVIDER_SMOKE=1 to call the real provider" },
   async () => {
     const root = makeRealProviderFixture();
     let success = false;
     try {
-      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:init", featureName), "kiro:spec:init");
-      assertRealProviderPhase(root, "initialized", ["requirements.md", "spec.json"]);
-
-      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:requirements", [`feature=${featureName}`, "-y"]), "kiro:spec:requirements");
-      assertRealProviderPhase(root, "requirements-generated", ["requirements.md"]);
-
-      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:design", [`feature=${featureName}`, "-y"]), "kiro:spec:design");
-      assertRealProviderPhase(root, "design-generated", ["requirements.md", "design.md"]);
-
-      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:spec:tasks", [`feature=${featureName}`, "-y"]), "kiro:spec:tasks");
+      writeParallelProviderSmokeImplementationArtifacts(root);
       assertRealProviderPhase(root, "tasks-generated", ["requirements.md", "design.md", "tasks.md"]);
       const tasksSpec = readSpec(root);
       assert.equal(tasksSpec.ready_for_implementation, true);
+      assert.match(readFileSync(join(root, ".kiro", "specs", featureName, "tasks.md"), "utf8"), /\(P\)/);
+      commitFixtureState(root, "real provider parallel implementation tasks");
 
-      assertRealProviderWorkflowSuccess(await runWorkflow(root, "kiro:impl", `feature=${featureName}`), "kiro:impl");
-      assertRealProviderSmokeOutcome(root);
+      const implResult = await runWorkflow(root, "kiro:impl", `feature=${featureName}`, {
+        successWhen: ({ root }) => hasCollectedWaveResults(root),
+      });
+      assertRealProviderEarlySmokeSuccess(implResult, "kiro:impl");
+      const implOutput = stripAnsi(implResult.output);
+      assert.match(implOutput, /plan-dispatch/, implOutput);
+      assert.match(implOutput, /prepare-task-wave/, implOutput);
+      assert.match(implOutput, /execute-task-wave/, implOutput);
+      assert.match(implOutput, /collect-wave-results/, implOutput);
+      assertRealProviderWaveSmokeOutcome(root);
       success = true;
     } finally {
       if (success && process.env.KIRO_REAL_PROVIDER_KEEP !== "1") {


### PR DESCRIPTION
## Summary

- Add a TeamLeader-backed `(P)` task wave path to the TAKT `kiro-impl` workflow, while preserving the existing one-task route for non-parallel tasks.
- Add wave planning, preparation, execution, collection, and apply adapter facets in English and Japanese.
- Update validators and smoke coverage so `(P)` tasks exercise the parallel path with isolated worktrees/branches.
- Make the real-provider smoke honor repository `.takt/config.yaml` / `.takt/config.yml` settings instead of forcing a provider.
- Align local facet parents and package lock with `takt@0.46.0` so CI prompt validation resolves the current built-in review facets.

## Validation

- `KIRO_REAL_PROVIDER_SMOKE=1 KIRO_REAL_PROVIDER_CODEX_HOME=/Users/j5ik2o/.codex-personal KIRO_REAL_PROVIDER_VERBOSE=1 npm run test:kiro-real-provider-smoke`
- `npm run validate:all`
- `npm run test:all`
- `npm run validate:kiro-shared-contracts`
- `npm run validate:kiro-iterative-implementation-workflow`
- `git diff --check`
- CI-style `takt prompt` loop for all `.takt/{en,ja}/workflows/*.yaml`

## Notes

- Standalone `kiro-impl` skill files are intentionally not changed by this PR; TAKT-specific parallel-wave behavior lives in `.takt/*` workflow/facet assets.
- The real-provider smoke used local `.takt/config.yaml` provider/model settings, but `.takt/config.yaml` is intentionally not included in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core kiro-impl orchestration (git worktrees, merges, dispatch routing) and bumps takt; mistakes could mis-apply parallel work or skip quality gates, though validators and smokes target the new paths.
> 
> **Overview**
> Adds a **TeamLeader-backed parallel path** for safe `(P)` tasks in `kiro-impl`, while keeping the existing one-task loop for everything else.
> 
> **Workflow routing** starts at `plan-dispatch` instead of `plan-one-task`. Dispatch chooses `wave` (up to two eligible parallel leaf tasks), `wave_apply` (merge a ready isolated result), or `single` (unchanged path). New steps prepare git worktrees under `.takt/worktrees/kiro-impl/`, run TeamLeader parts in isolation, collect results from filesystem evidence, and apply **one** wave result at a time into the main worktree before `ai-quality-gate` and reviewers. After progress updates, remaining work loops back to `plan-dispatch`.
> 
> **Contracts and facets**: `kiro-implementation-result` gains `dispatch_mode`, wave metadata, and report-preservation rules; EN/JA adapter instructions cover dispatch, prepare, execute, collect, and apply. Several spec review facets switch parent from `review-requirements` to `review-pure` for `takt@0.46.0`.
> 
> **Tooling**: validators and tests guard wave routing, TeamLeader config, and contract fields; mock smoke expects an extra dispatch step; real-provider smoke targets parallel `(P)` tasks and reads provider from repo config. `kiro-staged.mjs` accepts `.takt/config.yml`; dependency bumps to `takt@0.46.0` (package `2.0.1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 361632b08a5eab5254f669a9e7098e564bfbf3c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->