### PR TITLE
[codex] Relax package migration changelog gate

### DIFF
--- a/scripts/validate-package-artifact.mjs
+++ b/scripts/validate-package-artifact.mjs
@@ -364,57 +364,12 @@ function validateReadmeMigration(errors, label, text) {
     "BREAKING BEHAVIOR CHANGE wording",
     /BREAKING BEHAVIOR CHANGE|破壊的挙動変更/i,
   );
-  requireDocPattern(
-    errors,
-    label,
-    text,
-    "no-major-version-bump wording",
-    /without a major version bump|major version を上げない|メジャーバージョンを上げない|major version.*上げない/i,
-  );
-}
-
-function validateChangelogMigration(errors, text) {
-  requireDocPattern(
-    errors,
-    "CHANGELOG.md",
-    text,
-    "BREAKING BEHAVIOR CHANGE entry",
-    /BREAKING BEHAVIOR CHANGE/i,
-  );
-  requireDocPattern(
-    errors,
-    "CHANGELOG.md",
-    text,
-    "init asset copy retirement",
-    /takt-sdd init.*asset copy.*retired|init asset copy.*retired|init.*asset copy.*廃止/i,
-  );
-  requireDocPattern(
-    errors,
-    "CHANGELOG.md",
-    text,
-    "package bundled runtime guidance",
-    /package[- ]bundled workflows\/facets|bundled workflows\/facets.*installed package|installed package.*bundled workflows\/facets/i,
-  );
-  requireDocPattern(
-    errors,
-    "CHANGELOG.md",
-    text,
-    "eject migration guidance",
-    /takt-sdd eject/i,
-  );
-  requireDocPattern(
-    errors,
-    "CHANGELOG.md",
-    text,
-    "no-major-version-bump wording",
-    /without a major version bump|major version を上げない|メジャーバージョンを上げない|major version.*上げない/i,
-  );
 }
 
 /**
- * Validate README and CHANGELOG migration guidance for the no-copy bundled
- * runtime. This keeps a breaking behavior change from disappearing while the
- * package still publishes without a major version bump.
+ * Validate README migration guidance for the no-copy bundled runtime. Release
+ * notes are generated separately, so this check avoids coupling package
+ * artifact validation to a specific CHANGELOG prose shape or versioning policy.
  *
  * @param {{ readme?: string, readmeJa?: string, changelog?: string }} docs
  * @returns {string[]}
@@ -424,7 +379,6 @@ export function validateDocumentationMigration(docs) {
 
   validateReadmeMigration(errors, "README.md", normalizeDoc(docs.readme));
   validateReadmeMigration(errors, "README.ja.md", normalizeDoc(docs.readmeJa));
-  validateChangelogMigration(errors, normalizeDoc(docs.changelog));
 
   return errors;
 }

--- a/scripts/validate-package-artifact.mjs
+++ b/scripts/validate-package-artifact.mjs
@@ -371,7 +371,7 @@ function validateReadmeMigration(errors, label, text) {
  * notes are generated separately, so this check avoids coupling package
  * artifact validation to a specific CHANGELOG prose shape or versioning policy.
  *
- * @param {{ readme?: string, readmeJa?: string, changelog?: string }} docs
+ * @param {{ readme?: string, readmeJa?: string }} docs
  * @returns {string[]}
  */
 export function validateDocumentationMigration(docs) {
@@ -530,7 +530,6 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const docErrors = validateDocumentationMigration({
     readme: readFileSync(join(repoRoot, "README.md"), "utf8"),
     readmeJa: readFileSync(join(repoRoot, "README.ja.md"), "utf8"),
-    changelog: readFileSync(join(repoRoot, "CHANGELOG.md"), "utf8"),
   });
   allErrors.push(...docErrors);
 

--- a/tests/takt-sdd-package-artifact.test.mjs
+++ b/tests/takt-sdd-package-artifact.test.mjs
@@ -613,7 +613,7 @@ test("main() guard calls validateDocumentationMigration (wiring assertion)", () 
 // ---------------------------------------------------------------------------
 // Documentation migration regression checks
 // ---------------------------------------------------------------------------
-test("validateDocumentationMigration: actual README and CHANGELOG contain no-copy migration guidance", () => {
+test("validateDocumentationMigration: actual README files contain no-copy migration guidance", () => {
   assert.equal(typeof validateDocumentationMigration, "function");
   const errors = validateDocumentationMigration({
     readme: readFileSync(join(repoRoot, "README.md"), "utf8"),
@@ -630,21 +630,20 @@ test("validateDocumentationMigration: missing README manual script example is re
       "Package-bundled workflows/facets run from the installed package.",
       "Use takt-sdd eject for customization.",
       "takt-sdd init and create-takt-sdd are retired guidance-only commands.",
-      "BREAKING BEHAVIOR CHANGE without a major version bump.",
+      "BREAKING BEHAVIOR CHANGE.",
     ].join("\n"),
     readmeJa: [
       "package bundled workflows/facets は installed package から実行されます。",
       "カスタマイズには takt-sdd eject を使います。",
       "takt-sdd init と create-takt-sdd は retired guidance only です。",
-      "major version を上げない BREAKING BEHAVIOR CHANGE です。",
+      "BREAKING BEHAVIOR CHANGE です。",
       "\"kiro:impl\": \"takt-sdd kiro-impl\"",
     ].join("\n"),
     changelog: [
-      "### BREAKING BEHAVIOR CHANGE",
-      "takt-sdd init asset copy is retired.",
-      "Package bundled workflows/facets run from the installed package.",
-      "Use takt-sdd eject for customization.",
-      "This ships without a major version bump.",
+      "## [2.2.0]",
+      "### Features",
+      "* **no-copy-bundled-assets-eject:** run bundled workflows without init",
+      "* **no-copy-bundled-assets-eject:** wire eject into cli dispatch",
     ].join("\n"),
   };
   const errors = validateDocumentationMigration(docs);
@@ -654,7 +653,7 @@ test("validateDocumentationMigration: missing README manual script example is re
   );
 });
 
-test("validateDocumentationMigration: missing CHANGELOG breaking behavior is reported", () => {
+test("validateDocumentationMigration: release-generated CHANGELOG prose is not a package gate", () => {
   assert.equal(typeof validateDocumentationMigration, "function");
   const docs = {
     readme: [
@@ -662,20 +661,46 @@ test("validateDocumentationMigration: missing CHANGELOG breaking behavior is rep
       "Use takt-sdd eject for customization.",
       "takt-sdd init and create-takt-sdd are retired guidance-only commands.",
       "\"kiro:impl\": \"takt-sdd kiro-impl\"",
-      "BREAKING BEHAVIOR CHANGE without a major version bump.",
+      "BREAKING BEHAVIOR CHANGE.",
     ].join("\n"),
     readmeJa: [
       "package bundled workflows/facets は installed package から実行されます。",
       "カスタマイズには takt-sdd eject を使います。",
       "takt-sdd init と create-takt-sdd は retired guidance only です。",
       "\"kiro:impl\": \"takt-sdd kiro-impl\"",
-      "major version を上げない BREAKING BEHAVIOR CHANGE です。",
+      "BREAKING BEHAVIOR CHANGE です。",
+    ].join("\n"),
+    changelog: [
+      "## [2.2.0]",
+      "### Features",
+      "* **no-copy-bundled-assets-eject:** run bundled workflows without init",
+      "* **no-copy-bundled-assets-eject:** wire eject into cli dispatch",
+    ].join("\n"),
+  };
+  assert.deepEqual(validateDocumentationMigration(docs), []);
+});
+
+test("validateDocumentationMigration: missing README breaking behavior is reported", () => {
+  assert.equal(typeof validateDocumentationMigration, "function");
+  const docs = {
+    readme: [
+      "Package-bundled workflows/facets run from the installed package.",
+      "Use takt-sdd eject for customization.",
+      "takt-sdd init and create-takt-sdd are retired guidance-only commands.",
+      "\"kiro:impl\": \"takt-sdd kiro-impl\"",
+    ].join("\n"),
+    readmeJa: [
+      "package bundled workflows/facets は installed package から実行されます。",
+      "カスタマイズには takt-sdd eject を使います。",
+      "takt-sdd init と create-takt-sdd は retired guidance only です。",
+      "\"kiro:impl\": \"takt-sdd kiro-impl\"",
+      "BREAKING BEHAVIOR CHANGE です。",
     ].join("\n"),
     changelog: "Maintenance release.",
   };
   const errors = validateDocumentationMigration(docs);
   assert.ok(
-    errors.some((e) => e.includes("CHANGELOG.md") && e.includes("BREAKING BEHAVIOR CHANGE")),
+    errors.some((e) => e.includes("README.md") && e.includes("BREAKING BEHAVIOR CHANGE")),
     `Errors: ${errors.join("; ")}`,
   );
 });


### PR DESCRIPTION
## Summary

- Stop requiring release-generated CHANGELOG prose for the no-copy bundled runtime migration gate.
- Stop requiring “without a major version bump” wording, because this repository allows breaking behavior changes without a major bump.
- Keep README/README.ja migration guidance and BREAKING BEHAVIOR CHANGE checks.
- Add a regression case for release-generated CHANGELOG shape.

## Root cause

The v2.2.0 publish run failed because package artifact validation coupled release eligibility to exact CHANGELOG prose and a versioning-policy phrase. The CHANGELOG is release-generated, while the durable migration guidance lives in README files.

## Validation

- `npm run validate:package-artifact`
- `npm run test:takt-sdd-package-artifact`
- `git diff --check`

## Notes

Fixes the package validation failure in Actions run 27730456936.

After this merges, rerunning the existing v2.2.0 tag will still use the old tagged code. Publishing 2.2.0 requires recreating the tag at the fixed commit, or cutting a follow-up patch release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect release-time documentation validation and tests; no runtime or packaging file-list logic is modified.
> 
> **Overview**
> **Package artifact validation** no longer blocks publishes on `CHANGELOG.md` content or “without a major version bump” phrasing.
> 
> `validateDocumentationMigration` now only scans **README.md** and **README.ja.md** for the no-copy bundled-runtime migration guidance (bundled runtime, `takt-sdd eject`, retired `init` / `create-takt-sdd`, npm script example, and **BREAKING BEHAVIOR CHANGE**). The main validator stops reading `CHANGELOG.md` for this gate.
> 
> Tests were updated to match: integration still requires real READMEs to pass; a new case asserts release-style changelog bullets do **not** fail validation; the old CHANGELOG-breaking test is replaced with a README missing **BREAKING BEHAVIOR CHANGE** check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b45fc06aa8be05689b71ed36957db1b349829c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->